### PR TITLE
Adding missing directive definition

### DIFF
--- a/src/main/java/com/kobylynskyi/graphql/codegen/GraphqlCodegen.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/GraphqlCodegen.java
@@ -4,6 +4,7 @@ import com.kobylynskyi.graphql.codegen.mapper.*;
 import com.kobylynskyi.graphql.codegen.model.GraphqlDefinitionType;
 import com.kobylynskyi.graphql.codegen.model.DefinitionTypeDeterminer;
 import com.kobylynskyi.graphql.codegen.model.MappingConfig;
+import com.kobylynskyi.graphql.codegen.model.UnsupportedGraphqlDefinitionException;
 import freemarker.template.TemplateException;
 import graphql.language.*;
 import lombok.Getter;
@@ -52,7 +53,11 @@ public class GraphqlCodegen {
 
     private void processDocument(Document document) throws IOException, TemplateException {
         for (Definition definition : document.getDefinitions()) {
-            GraphqlDefinitionType definitionType = DefinitionTypeDeterminer.determine(definition);
+            try {
+                GraphqlDefinitionType definitionType = DefinitionTypeDeterminer.determine(definition);
+            } catch (UnsupportedGraphqlDefinitionException ex) {
+                continue;
+            }
             switch (definitionType) {
                 case OPERATION:
                     generateOperation((ObjectTypeDefinition) definition);

--- a/src/main/java/com/kobylynskyi/graphql/codegen/GraphqlCodegen.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/GraphqlCodegen.java
@@ -53,8 +53,9 @@ public class GraphqlCodegen {
 
     private void processDocument(Document document) throws IOException, TemplateException {
         for (Definition definition : document.getDefinitions()) {
+            GraphqlDefinitionType definitionType;
             try {
-                GraphqlDefinitionType definitionType = DefinitionTypeDeterminer.determine(definition);
+                definitionType = DefinitionTypeDeterminer.determine(definition);
             } catch (UnsupportedGraphqlDefinitionException ex) {
                 continue;
             }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/model/DefinitionTypeDeterminer.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/model/DefinitionTypeDeterminer.java
@@ -26,6 +26,8 @@ public class DefinitionTypeDeterminer {
             return GraphqlDefinitionType.SCALAR;
         } else if (definition instanceof InterfaceTypeDefinition) {
             return GraphqlDefinitionType.INTERFACE;
+        } else if (definition instanceof DirectiveDefinition) {
+            return GraphqlDefinitionType.DIRECTIVE;
         } else {
             throw new UnsupportedGraphqlDefinitionException(definition);
         }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/model/GraphqlDefinitionType.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/model/GraphqlDefinitionType.java
@@ -9,6 +9,7 @@ public enum GraphqlDefinitionType {
     INPUT,
     UNION,
     ENUM,
-    SCALAR;
+    SCALAR,
+    DIRECTIVE;
 
 }


### PR DESCRIPTION
This change should add a handler for the case where there are Directives in the schema which at the moment causes the code gen to throw and exception.

It also handles the exception in case there are other missed definitions.