### PR TITLE
External MappingConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ out
 build
 .idea
 .gradle
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id "maven-publish"
 }
 
-version = "1.2.3"
+version = "1.3.0"
 group = "io.github.kobylynskyi"
 
 repositories {
@@ -18,6 +18,7 @@ repositories {
 dependencies {
     compile "org.freemarker:freemarker:2.3.28"
     compile "com.graphql-java:graphql-java:13.0"
+    compile "com.google.code.gson:gson:2.8.6"
 
     compileOnly "org.projectlombok:lombok:1.18.8"
     annotationProcessor "org.projectlombok:lombok:1.18.8"
@@ -98,6 +99,11 @@ publishing {
                         id = "kobylynskyi"
                         name = "Bogdan Kobylynskyi"
                         email = "92bogdan@gmail.com"
+                    }
+                    developer {
+                        id = "valinha"
+                        name = "Alberto Valiña"
+                        email = "valinhadev@gmail.com"
                     }
                 }
             }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/GraphqlCodegen.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/GraphqlCodegen.java
@@ -1,10 +1,8 @@
 package com.kobylynskyi.graphql.codegen;
 
 import com.kobylynskyi.graphql.codegen.mapper.*;
-import com.kobylynskyi.graphql.codegen.model.DefinitionTypeDeterminer;
-import com.kobylynskyi.graphql.codegen.model.GraphqlDefinitionType;
-import com.kobylynskyi.graphql.codegen.model.MappingConfig;
-import com.kobylynskyi.graphql.codegen.model.UnsupportedGraphqlDefinitionException;
+import com.kobylynskyi.graphql.codegen.model.*;
+import com.kobylynskyi.graphql.codegen.supplier.MappingConfigSupplier;
 import freemarker.template.TemplateException;
 import graphql.language.*;
 import lombok.Getter;
@@ -14,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Generator of:
@@ -25,6 +24,7 @@ import java.util.Map;
  * - Class for each GraphQL scalar type
  *
  * @author kobylynskyi
+ * @author valinhadev
  */
 @Getter
 @Setter
@@ -33,12 +33,33 @@ public class GraphqlCodegen {
     private List<String> schemas;
     private File outputDir;
     private MappingConfig mappingConfig;
+    private MappingConfig result;
 
     public GraphqlCodegen(List<String> schemas, File outputDir, MappingConfig mappingConfig) {
+        this(schemas, outputDir, mappingConfig, null);
+    }
+
+
+    public GraphqlCodegen(List<String> schemas, File outputDir, MappingConfig mappingConfig, MappingConfigSupplier externalMappingConfigSupplier) {
         this.schemas = schemas;
         this.outputDir = outputDir;
         this.mappingConfig = mappingConfig;
+        this.mappingConfig.combine(externalMappingConfigSupplier != null ? externalMappingConfigSupplier.get() : null);
+        initDefaultValues(mappingConfig);
     }
+
+    private void initDefaultValues(MappingConfig mappingConfig) {
+        if (mappingConfig.getModelValidationAnnotation() == null) {
+            mappingConfig.setModelValidationAnnotation(DefaultMappingConfigValues.DEFAULT_VALIDATION_ANNOTATION);
+        }
+        if (mappingConfig.getGenerateEqualsAndHashCode() == null) {
+            mappingConfig.setGenerateEqualsAndHashCode(DefaultMappingConfigValues.DEFAULT_EQUALS_AND_HASHCODE);
+        }
+        if (mappingConfig.getGenerateApis() == null) {
+            mappingConfig.setGenerateApis(DefaultMappingConfigValues.DEFAULT_GENERATE_APIS);
+        }
+    }
+
 
     public void generate() throws Exception {
         GraphqlCodegenFileCreator.prepareOutputDir(outputDir);
@@ -94,7 +115,7 @@ public class GraphqlCodegen {
     }
 
     private void generateOperation(ObjectTypeDefinition definition) throws IOException, TemplateException {
-        if (mappingConfig.isGenerateApis()) {
+        if (Boolean.TRUE.equals(mappingConfig.getGenerateApis())) {
             for (FieldDefinition fieldDef : definition.getFieldDefinitions()) {
                 Map<String, Object> dataModel = FieldDefinitionToDataModelMapper.map(mappingConfig, fieldDef, definition.getName());
                 GraphqlCodegenFileCreator.generateFile(FreeMarkerTemplatesRegistry.operationsTemplate, dataModel, outputDir);

--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/InputDefinitionToDataModelMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/InputDefinitionToDataModelMapper.java
@@ -30,7 +30,7 @@ public class InputDefinitionToDataModelMapper {
         dataModel.put(CLASS_NAME, MapperUtils.getClassNameWithPrefixAndSuffix(mappingConfig, typeDefinition));
         dataModel.put(NAME, typeDefinition.getName());
         dataModel.put(FIELDS, InputValueDefinitionToParameterMapper.map(mappingConfig, typeDefinition.getInputValueDefinitions(), typeDefinition.getName()));
-        dataModel.put(EQUALS_AND_HASH_CODE, mappingConfig.isGenerateEqualsAndHashCode());
+        dataModel.put(EQUALS_AND_HASH_CODE, mappingConfig.getGenerateEqualsAndHashCode());
         return dataModel;
     }
 

--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/TypeDefinitionToDataModelMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/TypeDefinitionToDataModelMapper.java
@@ -48,7 +48,7 @@ public class TypeDefinitionToDataModelMapper {
                 .map(i -> FieldDefinitionToParameterMapper.map(mappingConfig, i.getFieldDefinitions(), i.getName()))
                 .forEach(allParameters::addAll);
         dataModel.put(FIELDS, allParameters);
-        dataModel.put(EQUALS_AND_HASH_CODE, mappingConfig.isGenerateEqualsAndHashCode());
+        dataModel.put(EQUALS_AND_HASH_CODE, mappingConfig.getGenerateEqualsAndHashCode());
 
         return dataModel;
     }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/model/Combinable.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/model/Combinable.java
@@ -1,0 +1,17 @@
+package com.kobylynskyi.graphql.codegen.model;
+
+/**
+ * The interface Combinable.
+ *
+ * @param <T> the type parameter
+ * @author valinha
+ */
+@FunctionalInterface
+public interface Combinable<T> {
+    /**
+     * Combine with source.
+     *
+     * @param source the source
+     */
+    void combine(T source);
+}

--- a/src/main/java/com/kobylynskyi/graphql/codegen/model/MappingConfig.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/model/MappingConfig.java
@@ -5,8 +5,14 @@ import lombok.Data;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * The type Mapping config.
+ *
+ * @author kobylynskyi
+ * @author valinha
+ */
 @Data
-public class MappingConfig {
+public class MappingConfig implements Combinable<MappingConfig> {
 
     /**
      * Scalars mapping can be defined here.
@@ -21,15 +27,21 @@ public class MappingConfig {
      */
     private Map<String, String> customAnnotationsMapping = new HashMap<>();
 
-    private boolean generateApis = DefaultMappingConfigValues.DEFAULT_GENERATE_APIS;
+    private Boolean generateApis;
     private String packageName;
     private String apiPackageName;
     private String modelPackageName;
     private String modelNamePrefix;
     private String modelNameSuffix;
-    private String modelValidationAnnotation = DefaultMappingConfigValues.DEFAULT_VALIDATION_ANNOTATION;
-    private boolean generateEqualsAndHashCode = DefaultMappingConfigValues.DEFAULT_EQUALS_AND_HASHCODE;
+    private String modelValidationAnnotation;
+    private Boolean generateEqualsAndHashCode;
 
+    /**
+     * Put custom type mapping if absent.
+     *
+     * @param from the from
+     * @param to   the to
+     */
     public void putCustomTypeMappingIfAbsent(String from, String to) {
         if (customTypesMapping == null) {
             customTypesMapping = new HashMap<>();
@@ -39,4 +51,28 @@ public class MappingConfig {
         }
     }
 
+
+    @Override
+    public void combine(MappingConfig source) {
+        if (source != null) {
+            if (this.customTypesMapping != null && source.customTypesMapping != null) {
+                this.customTypesMapping.putAll(source.customTypesMapping);
+            } else if (this.customTypesMapping == null && source.customTypesMapping != null) {
+                this.customTypesMapping = source.customTypesMapping;
+            }
+            if (this.customAnnotationsMapping != null && source.customAnnotationsMapping != null) {
+                this.customAnnotationsMapping.putAll(source.customAnnotationsMapping);
+            } else if (this.customAnnotationsMapping == null && source.customAnnotationsMapping != null) {
+                this.customAnnotationsMapping = source.customAnnotationsMapping;
+            }
+            this.generateApis = source.generateApis != null ? source.generateApis : this.generateApis;
+            this.packageName = source.packageName != null ? source.packageName : this.packageName;
+            this.apiPackageName = source.apiPackageName != null ? source.apiPackageName : this.apiPackageName;
+            this.modelPackageName = source.modelPackageName != null ? source.modelPackageName : this.modelPackageName;
+            this.modelNamePrefix = source.modelNamePrefix != null ? source.modelNamePrefix : this.modelNamePrefix;
+            this.modelNameSuffix = source.modelNameSuffix != null ? source.modelNameSuffix : this.modelNameSuffix;
+            this.modelValidationAnnotation = source.modelValidationAnnotation != null ? source.modelValidationAnnotation : this.modelValidationAnnotation;
+            this.generateEqualsAndHashCode = source.generateEqualsAndHashCode != null ? source.generateEqualsAndHashCode : this.generateEqualsAndHashCode;
+        }
+    }
 }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/supplier/JsonMappingConfigSupplier.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/supplier/JsonMappingConfigSupplier.java
@@ -1,0 +1,39 @@
+package com.kobylynskyi.graphql.codegen.supplier;
+
+import com.google.gson.GsonBuilder;
+import com.kobylynskyi.graphql.codegen.model.MappingConfig;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+
+/**
+ * Retrieve a MappingConfig fro json configuration file.
+ *
+ * @author valinha
+ */
+public class JsonMappingConfigSupplier implements MappingConfigSupplier {
+
+    private String jsonConfigFile;
+
+    /**
+     * Instantiates a new Json configuration file supplier.
+     *
+     * @param jsonConfigFile the json config file
+     */
+    public JsonMappingConfigSupplier(String jsonConfigFile) {
+        this.jsonConfigFile = jsonConfigFile;
+    }
+
+    @Override
+    public MappingConfig get() {
+        if (jsonConfigFile != null && !jsonConfigFile.isEmpty()) {
+            try {
+                return new GsonBuilder().create().fromJson(new FileReader(new File(jsonConfigFile)), MappingConfig.class);
+            } catch (FileNotFoundException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/kobylynskyi/graphql/codegen/supplier/MappingConfigSupplier.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/supplier/MappingConfigSupplier.java
@@ -1,0 +1,13 @@
+package com.kobylynskyi.graphql.codegen.supplier;
+
+import com.kobylynskyi.graphql.codegen.model.MappingConfig;
+
+import java.util.function.Supplier;
+
+/**
+ * The interface Mapping config supplier.
+ * @author valinha
+ */
+public interface MappingConfigSupplier extends Supplier<MappingConfig> {
+    //mark interface
+}

--- a/src/main/java/com/kobylynskyi/graphql/codegen/utils/Utils.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/utils/Utils.java
@@ -1,8 +1,12 @@
 package com.kobylynskyi.graphql.codegen.utils;
 
+import com.google.gson.GsonBuilder;
+import com.kobylynskyi.graphql.codegen.model.MappingConfig;
 import graphql.language.OperationDefinition;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -113,4 +117,6 @@ public final class Utils {
             throw new IOException("Unable to create output directory");
         }
     }
+
+
 }

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenExternalConfigTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenExternalConfigTest.java
@@ -1,0 +1,51 @@
+package com.kobylynskyi.graphql.codegen;
+
+import com.kobylynskyi.graphql.codegen.model.MappingConfig;
+import com.kobylynskyi.graphql.codegen.supplier.JsonMappingConfigSupplier;
+import com.kobylynskyi.graphql.codegen.utils.Utils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The type Graphql codegen external config test.
+ *
+ * @author valinha
+ */
+class GraphqlCodegenExternalConfigTest {
+
+    /**
+     * Check mapping config from json file.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    void check_mappingConfigFromJsonFile() throws Exception {
+        MappingConfig externalMappingConfig = new JsonMappingConfigSupplier("src/test/resources/json/mappingconfig.json").get();
+
+        assertEquals(externalMappingConfig.getPackageName(), "com.kobylynskyi.graphql.testconfigjson");
+        assertEquals(externalMappingConfig.getGenerateApis(), true);
+        assertEquals(externalMappingConfig.getCustomTypesMapping().get("Price.amount"), "java.math.BigDecimal");
+        assertNull(externalMappingConfig.getApiPackageName());
+    }
+
+
+    /**
+     * Check combine mapping config with external.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    void check_combineMappingConfigWithExternal() throws Exception {
+        MappingConfig mappingConfig = new MappingConfig();
+        mappingConfig.setPackageName("com.kobylynskyi.graphql.test1");
+
+        MappingConfig externalMappingConfig = new MappingConfig();
+        externalMappingConfig.setPackageName("com.kobylynskyi.graphql.testconfig");
+        mappingConfig.combine(externalMappingConfig);
+        assertEquals(externalMappingConfig.getPackageName(), mappingConfig.getPackageName());
+    }
+
+
+}

--- a/src/test/resources/json/mappingconfig.json
+++ b/src/test/resources/json/mappingconfig.json
@@ -1,0 +1,7 @@
+{
+  "generateApis": true,
+  "packageName": "com.kobylynskyi.graphql.testconfigjson",
+  "customTypesMapping": {
+    "Price.amount": "java.math.BigDecimal"
+  }
+}


### PR DESCRIPTION
Possibility to configure a MappingConfigSupplier to provide an external MappingConfig.
Library offers a JsonMappingConfigSupplier thats provide an external MappingConfig from a json file.
The external configuration will be merge with de original configuration. 