### PR TITLE
Add default values generation

### DIFF
--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/DefaultValueMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/DefaultValueMapper.java
@@ -1,0 +1,99 @@
+package com.kobylynskyi.graphql.codegen.mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import graphql.language.ArrayValue;
+import graphql.language.BooleanValue;
+import graphql.language.EnumValue;
+import graphql.language.FloatValue;
+import graphql.language.IntValue;
+import graphql.language.ListType;
+import graphql.language.NonNullType;
+import graphql.language.NullValue;
+import graphql.language.ObjectValue;
+import graphql.language.StringValue;
+import graphql.language.Type;
+import graphql.language.TypeName;
+import graphql.language.Value;
+
+public class DefaultValueMapper {
+
+    public static String map(Value<?> defaultValue, Type<?> graphQLType) {
+        if (defaultValue instanceof NullValue) {
+            return mapNullValue();
+        }
+        if (defaultValue instanceof BooleanValue) {
+            return mapBoolean((BooleanValue)defaultValue);
+        }
+        if (defaultValue instanceof IntValue) {
+            return mapInt((IntValue)defaultValue);
+        }
+        if (defaultValue instanceof FloatValue) {
+            return mapFloat((FloatValue)defaultValue);
+        }
+        if (defaultValue instanceof StringValue) {
+            return mapString((StringValue) defaultValue);
+        }
+        if (defaultValue instanceof EnumValue) {
+            return mapEnum(graphQLType, (EnumValue) defaultValue);
+        }
+        if (defaultValue instanceof ObjectValue) {
+            return mapObject((ObjectValue) defaultValue);
+        }
+        if (defaultValue instanceof ArrayValue) {
+            return mapArray((ArrayValue) defaultValue, graphQLType);
+        }
+        // no default value, or not a known type
+        return null;
+    }
+
+    private static String mapNullValue() {
+        return "null";
+    }
+
+    private static String mapBoolean(BooleanValue defaultValue) {
+        return defaultValue.isValue() ? "true" : "false";
+    }
+
+    private static String mapInt(IntValue defaultValue) {
+        return String.valueOf(defaultValue.getValue());
+    }
+
+    private static String mapFloat(FloatValue defaultValue) {
+        return defaultValue.getValue() + "f";
+    }
+
+    private static String mapString(StringValue defaultValue) {
+        return "\"" + defaultValue.getValue() + "\"";
+    }
+
+    private static String mapEnum(Type<?> graphQLType, EnumValue defaultValue) {
+        if (graphQLType instanceof TypeName) {
+            return ((TypeName) graphQLType).getName() + "." + defaultValue.getName();
+        }
+        if (graphQLType instanceof NonNullType) {
+            return mapEnum(((NonNullType) graphQLType).getType(), defaultValue);
+        }
+        throw new IllegalArgumentException("Unexpected Enum default value for list type");
+    }
+
+    private static String mapObject(ObjectValue defaultValue) {
+        // default object values are not supported yet, same behaviour as before for those
+        return null;
+    }
+
+    private static String mapArray(ArrayValue defaultValue, Type<?> graphQLType) {
+        if (!(graphQLType instanceof ListType)) {
+            throw new IllegalArgumentException("Unexpected array default value for non-list type");
+        }
+        List<Value> values = defaultValue.getValues();
+        if (values.isEmpty()) {
+            return "Collections.emptyList()";
+        }
+        Type<?> elementType = ((ListType) graphQLType).getType();
+        return values.stream()
+                     .map(v -> map(v, elementType))
+                     .collect(Collectors.joining(", ", "List.of(", ")"));
+    }
+}

--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/DefaultValueMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/DefaultValueMapper.java
@@ -94,6 +94,6 @@ public class DefaultValueMapper {
         Type<?> elementType = ((ListType) graphQLType).getType();
         return values.stream()
                      .map(v -> map(v, elementType))
-                     .collect(Collectors.joining(", ", "List.of(", ")"));
+                     .collect(Collectors.joining(", ", "Arrays.asList(", ")"));
     }
 }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/GraphqlTypeToJavaTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/GraphqlTypeToJavaTypeMapper.java
@@ -46,6 +46,7 @@ class GraphqlTypeToJavaTypeMapper {
         ParameterDefinition parameter = new ParameterDefinition();
         parameter.setName(MapperUtils.capitalizeIfRestricted(inputValueDefinition.getName()));
         parameter.setType(getJavaType(mappingConfig, inputValueDefinition.getType()));
+        parameter.setDefaultValue(DefaultValueMapper.map(inputValueDefinition.getDefaultValue(), inputValueDefinition.getType()));
         parameter.setAnnotations(getAnnotations(mappingConfig, inputValueDefinition.getType(), inputValueDefinition.getName(), parentTypeName));
         return parameter;
     }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/model/ParameterDefinition.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/model/ParameterDefinition.java
@@ -15,6 +15,6 @@ public class ParameterDefinition {
 
     private String type;
     private String name;
+    private String defaultValue;
     private List<String> annotations = new ArrayList<>();
-
 }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/utils/Utils.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/utils/Utils.java
@@ -72,7 +72,7 @@ public final class Utils {
      * @throws IOException unable to read the file.
      */
     public static String getFileContent(String filePath) throws IOException {
-        return new String(Files.readAllBytes(Paths.get(filePath)));
+        return new String(Files.readAllBytes(Paths.get(filePath))).trim();
     }
 
     /**

--- a/src/main/resources/templates/javaClassGraphqlType.ftl
+++ b/src/main/resources/templates/javaClassGraphqlType.ftl
@@ -12,7 +12,7 @@ public class ${className} <#if implements?has_content>implements <#list implemen
 <#list field.annotations as annotation>
     @${annotation}
 </#list>
-    private ${field.type} ${field.name};
+    private ${field.type} ${field.name}<#if field.defaultValue?has_content> = ${field.defaultValue}</#if>;
 </#list>
 
     public ${className}() {

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenDefaultsTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenDefaultsTest.java
@@ -1,0 +1,53 @@
+package com.kobylynskyi.graphql.codegen;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.kobylynskyi.graphql.codegen.model.MappingConfig;
+import com.kobylynskyi.graphql.codegen.utils.Utils;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GraphqlCodegenDefaultsTest {
+
+    private GraphqlCodegen generator;
+
+    private File outputBuildDir = new File("build/generated");
+    private File outputJavaClassesDir = new File("build/generated/com/kobylynskyi/graphql/testdefaults");
+
+    @BeforeEach
+    void init() {
+        MappingConfig mappingConfig = new MappingConfig();
+        mappingConfig.setPackageName("com.kobylynskyi.graphql.testdefaults");
+        generator = new GraphqlCodegen(Collections.singletonList("src/test/resources/schemas/defaults.graphqls"),
+                outputBuildDir, mappingConfig);
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        Utils.deleteDir(new File("build/generated"));
+    }
+
+    @Test
+    void generate_CheckFiles() throws Exception {
+        generator.generate();
+
+        File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
+        List<String> generatedFileNames = Arrays.stream(files).map(File::getName).sorted().collect(toList());
+        assertEquals(Arrays.asList("InputWithDefaults.java", "MyEnum.java", "SomeObject.java"), generatedFileNames);
+
+        for (File file : files) {
+            File expected = new File(String.format("src/test/resources/expected-classes/%s.txt", file.getName()));
+            assertEquals(Utils.getFileContent(expected.getPath()), Utils.getFileContent(file.getPath()));
+        }
+    }
+}

--- a/src/test/resources/expected-classes/InputWithDefaults.java.txt
+++ b/src/test/resources/expected-classes/InputWithDefaults.java.txt
@@ -1,0 +1,114 @@
+package com.kobylynskyi.graphql.testdefaults;
+
+import java.util.*;
+
+public class InputWithDefaults {
+
+    private Float floatVal = 1.23f;
+    private Boolean booleanVal = false;
+    private Integer intVal = 42;
+    private String stringVal = "my-default";
+    private MyEnum enumVal = MyEnum.ONE;
+    @javax.validation.constraints.NotNull
+    private MyEnum nonNullEnumVal = MyEnum.TWO;
+    private SomeObject objectWithNullDefault = null;
+    private SomeObject objectWithNonNullDefault;
+    private Collection<Integer> intList = List.of(1, 2, 3);
+    private Collection<Integer> intListEmptyDefault = Collections.emptyList();
+    private Collection<SomeObject> objectListEmptyDefault = Collections.emptyList();
+
+    public InputWithDefaults() {
+    }
+
+    public InputWithDefaults(Float floatVal, Boolean booleanVal, Integer intVal, String stringVal, MyEnum enumVal, MyEnum nonNullEnumVal, SomeObject objectWithNullDefault, SomeObject objectWithNonNullDefault, Collection<Integer> intList, Collection<Integer> intListEmptyDefault, Collection<SomeObject> objectListEmptyDefault) {
+        this.floatVal = floatVal;
+        this.booleanVal = booleanVal;
+        this.intVal = intVal;
+        this.stringVal = stringVal;
+        this.enumVal = enumVal;
+        this.nonNullEnumVal = nonNullEnumVal;
+        this.objectWithNullDefault = objectWithNullDefault;
+        this.objectWithNonNullDefault = objectWithNonNullDefault;
+        this.intList = intList;
+        this.intListEmptyDefault = intListEmptyDefault;
+        this.objectListEmptyDefault = objectListEmptyDefault;
+    }
+
+    public Float getFloatVal() {
+        return floatVal;
+    }
+    public void setFloatVal(Float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    public Boolean getBooleanVal() {
+        return booleanVal;
+    }
+    public void setBooleanVal(Boolean booleanVal) {
+        this.booleanVal = booleanVal;
+    }
+
+    public Integer getIntVal() {
+        return intVal;
+    }
+    public void setIntVal(Integer intVal) {
+        this.intVal = intVal;
+    }
+
+    public String getStringVal() {
+        return stringVal;
+    }
+    public void setStringVal(String stringVal) {
+        this.stringVal = stringVal;
+    }
+
+    public MyEnum getEnumVal() {
+        return enumVal;
+    }
+    public void setEnumVal(MyEnum enumVal) {
+        this.enumVal = enumVal;
+    }
+
+    public MyEnum getNonNullEnumVal() {
+        return nonNullEnumVal;
+    }
+    public void setNonNullEnumVal(MyEnum nonNullEnumVal) {
+        this.nonNullEnumVal = nonNullEnumVal;
+    }
+
+    public SomeObject getObjectWithNullDefault() {
+        return objectWithNullDefault;
+    }
+    public void setObjectWithNullDefault(SomeObject objectWithNullDefault) {
+        this.objectWithNullDefault = objectWithNullDefault;
+    }
+
+    public SomeObject getObjectWithNonNullDefault() {
+        return objectWithNonNullDefault;
+    }
+    public void setObjectWithNonNullDefault(SomeObject objectWithNonNullDefault) {
+        this.objectWithNonNullDefault = objectWithNonNullDefault;
+    }
+
+    public Collection<Integer> getIntList() {
+        return intList;
+    }
+    public void setIntList(Collection<Integer> intList) {
+        this.intList = intList;
+    }
+
+    public Collection<Integer> getIntListEmptyDefault() {
+        return intListEmptyDefault;
+    }
+    public void setIntListEmptyDefault(Collection<Integer> intListEmptyDefault) {
+        this.intListEmptyDefault = intListEmptyDefault;
+    }
+
+    public Collection<SomeObject> getObjectListEmptyDefault() {
+        return objectListEmptyDefault;
+    }
+    public void setObjectListEmptyDefault(Collection<SomeObject> objectListEmptyDefault) {
+        this.objectListEmptyDefault = objectListEmptyDefault;
+    }
+
+}

--- a/src/test/resources/expected-classes/InputWithDefaults.java.txt
+++ b/src/test/resources/expected-classes/InputWithDefaults.java.txt
@@ -13,7 +13,7 @@ public class InputWithDefaults {
     private MyEnum nonNullEnumVal = MyEnum.TWO;
     private SomeObject objectWithNullDefault = null;
     private SomeObject objectWithNonNullDefault;
-    private Collection<Integer> intList = List.of(1, 2, 3);
+    private Collection<Integer> intList = Arrays.asList(1, 2, 3);
     private Collection<Integer> intListEmptyDefault = Collections.emptyList();
     private Collection<SomeObject> objectListEmptyDefault = Collections.emptyList();
 

--- a/src/test/resources/expected-classes/MyEnum.java.txt
+++ b/src/test/resources/expected-classes/MyEnum.java.txt
@@ -1,0 +1,9 @@
+package com.kobylynskyi.graphql.testdefaults;
+
+public enum MyEnum {
+
+    ONE, 
+    TWO, 
+    THREE
+
+}

--- a/src/test/resources/expected-classes/SomeObject.java.txt
+++ b/src/test/resources/expected-classes/SomeObject.java.txt
@@ -1,0 +1,24 @@
+package com.kobylynskyi.graphql.testdefaults;
+
+import java.util.*;
+
+public class SomeObject {
+
+    @javax.validation.constraints.NotNull
+    private String name;
+
+    public SomeObject() {
+    }
+
+    public SomeObject(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/src/test/resources/schemas/defaults.graphqls
+++ b/src/test/resources/schemas/defaults.graphqls
@@ -1,0 +1,23 @@
+
+# This input has all possible types
+input InputWithDefaults {
+    floatVal: Float = 1.23
+    booleanVal: Boolean = false
+    intVal: Int = 42
+    stringVal: String = "my-default"
+    enumVal: MyEnum = ONE
+    nonNullEnumVal: MyEnum! = TWO
+    objectWithNullDefault: SomeObject = null
+    objectWithNonNullDefault: SomeObject = { name: "Bob" }
+    intList: [Int] = [1, 2, 3]
+    intListEmptyDefault: [Int] = []
+    objectListEmptyDefault: [SomeObject] = []
+}
+
+input SomeObject {
+    name: String!
+}
+
+enum MyEnum {
+    ONE, TWO, THREE
+}


### PR DESCRIPTION
Hey, this is a draft for the support of default values, I just experimented a little bit with my current use case, and everything seems to work well for enum defaults, lists, integers, strings.

I tried to update the tests, but adding default values to the github schema didn't break the existing tests. Maybe not everything in the schema is actually compared to expected output.

Would you be interested in adding this feature?
This is crucial for our use case at my company, default values for input types should be set in the generated code, otherwise it's a huge burden.