### PR TITLE
Cleanup: remove residual trim() added in previous PR

### DIFF
--- a/src/main/java/com/kobylynskyi/graphql/codegen/GraphqlCodegen.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/GraphqlCodegen.java
@@ -12,7 +12,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 /**
  * Generator of:
@@ -76,7 +75,7 @@ public class GraphqlCodegen {
     }
 
     private void processDocument(Document document) throws IOException, TemplateException {
-        for (Definition definition : document.getDefinitions()) {
+        for (Definition<?> definition : document.getDefinitions()) {
             GraphqlDefinitionType definitionType;
             try {
                 definitionType = DefinitionTypeDeterminer.determine(definition);
@@ -145,12 +144,11 @@ public class GraphqlCodegen {
     }
 
     private void addScalarsToCustomMappingConfig(Document document) {
-        for (Definition definition : document.getDefinitions()) {
+        for (Definition<?> definition : document.getDefinitions()) {
             if (definition instanceof ScalarTypeDefinition) {
                 String scalarName = ((ScalarTypeDefinition) definition).getName();
                 mappingConfig.putCustomTypeMappingIfAbsent(scalarName, "String");
             }
         }
     }
-
 }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/utils/Utils.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/utils/Utils.java
@@ -72,7 +72,7 @@ public final class Utils {
      * @throws IOException unable to read the file.
      */
     public static String getFileContent(String filePath) throws IOException {
-        return new String(Files.readAllBytes(Paths.get(filePath))).trim();
+        return new String(Files.readAllBytes(Paths.get(filePath)));
     }
 
     /**

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenDefaultsTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenDefaultsTest.java
@@ -47,7 +47,7 @@ class GraphqlCodegenDefaultsTest {
 
         for (File file : files) {
             File expected = new File(String.format("src/test/resources/expected-classes/%s.txt", file.getName()));
-            assertEquals(Utils.getFileContent(expected.getPath()), Utils.getFileContent(file.getPath()));
+            TestUtils.assertSameTrimmedContent(expected, file);
         }
     }
 }

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenGitHubTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenGitHubTest.java
@@ -13,8 +13,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
 
+import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class GraphqlCodegenGitHubTest {
 
@@ -41,16 +41,11 @@ class GraphqlCodegenGitHubTest {
         generator.generate();
 
         File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
-        File commitFile = Arrays.stream(files).filter(file -> file.getName().equalsIgnoreCase("Commit.java"))
-                .findFirst().orElseThrow(FileNotFoundException::new);
-        assertEquals(Utils.getFileContent(new File("src/test/resources/expected-classes/Commit.java.txt").getPath()),
-                Utils.getFileContent(commitFile.getPath()));
+        File commitFile = getGeneratedFile(files, "Commit.java");
+        assertSameTrimmedContent(new File("src/test/resources/expected-classes/Commit.java.txt"), commitFile);
 
-
-        File profileOwner = Arrays.stream(files).filter(file -> file.getName().equalsIgnoreCase("ProfileOwner.java"))
-                .findFirst().orElseThrow(FileNotFoundException::new);
-        assertEquals(Utils.getFileContent(new File("src/test/resources/expected-classes/ProfileOwner.java.txt").getPath()),
-                Utils.getFileContent(profileOwner.getPath()));
+        File profileOwner = getGeneratedFile(files, "ProfileOwner.java");
+        assertSameTrimmedContent(new File("src/test/resources/expected-classes/ProfileOwner.java.txt"), profileOwner);
     }
 
     @Test
@@ -75,12 +70,13 @@ class GraphqlCodegenGitHubTest {
                 StringContains.containsString("public interface GithubAssigneeTO "));
 
         // verify proper class name for GraphQL input
-        assertEquals(Utils.getFileContent(new File("src/test/resources/expected-classes/GithubAcceptTopicSuggestionInputTO.java.txt").getPath()),
-                getGeneratedFileContent(files, "GithubAcceptTopicSuggestionInputTO.java"));
+        assertSameTrimmedContent(
+                new File("src/test/resources/expected-classes/GithubAcceptTopicSuggestionInputTO.java.txt"),
+                getGeneratedFile(files, "GithubAcceptTopicSuggestionInputTO.java"));
 
         // verify proper class name for GraphQL type and references to interfaces/types/unions for GraphQL type
-        assertEquals(Utils.getFileContent(new File("src/test/resources/expected-classes/GithubCommitTO.java.txt").getPath()),
-                getGeneratedFileContent(files, "GithubCommitTO.java"));
+        assertSameTrimmedContent(new File("src/test/resources/expected-classes/GithubCommitTO.java.txt"),
+                getGeneratedFile(files, "GithubCommitTO.java"));
     }
 
     @Test
@@ -88,17 +84,20 @@ class GraphqlCodegenGitHubTest {
         mappingConfig.setModelValidationAnnotation(null);
 
         generator.generate();
-        File commitFile = Arrays.stream(Objects.requireNonNull(outputJavaClassesDir.listFiles()))
-                .filter(file -> file.getName().equalsIgnoreCase("Commit.java"))
-                .findFirst().orElseThrow(FileNotFoundException::new);
-        assertEquals(Utils.getFileContent(new File("src/test/resources/expected-classes/Commit_noValidationAnnotation.java.txt").getPath()),
-                Utils.getFileContent(commitFile.getPath()));
+        File commitFile = getGeneratedFile(Objects.requireNonNull(outputJavaClassesDir.listFiles()), "Commit.java");
+        assertSameTrimmedContent(new File("src/test/resources/expected-classes/Commit_noValidationAnnotation.java.txt"),
+                commitFile);
     }
 
     private static String getGeneratedFileContent(File[] files, String fileName) throws IOException {
-        File file = Arrays.stream(files).filter(f -> f.getName().equalsIgnoreCase(fileName))
-                .findFirst().orElseThrow(FileNotFoundException::new);
+        File file = getGeneratedFile(files, fileName);
         return Utils.getFileContent(file.getPath());
     }
 
+    private static File getGeneratedFile(File[] files, String fileName) throws FileNotFoundException {
+        return Arrays.stream(files)
+                     .filter(f -> f.getName().equalsIgnoreCase(fileName))
+                     .findFirst()
+                     .orElseThrow(FileNotFoundException::new);
+    }
 }

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.*;
 
+import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -55,7 +56,7 @@ class GraphqlCodegenTest {
 
         for (File file : files) {
             File expected = new File(String.format("src/test/resources/expected-classes/%s.txt", file.getName()));
-            assertEquals(Utils.getFileContent(expected.getPath()), Utils.getFileContent(file.getPath()));
+            assertSameTrimmedContent(expected, file);
         }
     }
 

--- a/src/test/java/com/kobylynskyi/graphql/codegen/TestUtils.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/TestUtils.java
@@ -1,0 +1,17 @@
+package com.kobylynskyi.graphql.codegen;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.kobylynskyi.graphql.codegen.utils.Utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestUtils {
+
+    public static void assertSameTrimmedContent(File expected, File file) throws IOException {
+        String expectedContent = Utils.getFileContent(expected.getPath()).trim();
+        String actualContent = Utils.getFileContent(file.getPath()).trim();
+        assertEquals(expectedContent, actualContent);
+    }
+}


### PR DESCRIPTION
In commit 96f7aa356cd17d2ea7f20b50235fe2eb492cca36, I had added a `trim()` call in `Utils.getFileContent()` because during my tests the generated files didn't contain an EOL at the end of the file, but some of my test files did.

I didn't realize this function was called in production code at the time.

This PR reverts this change but also adds a utility function for the tests to enable comparing trimmed file contents.