### PR TITLE
Fix class name in FieldResolver generation #58

### DIFF
--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/FieldResolverDefinitionToDataModelMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/FieldResolverDefinitionToDataModelMapper.java
@@ -34,12 +34,11 @@ public class FieldResolverDefinitionToDataModelMapper {
     public static Map<String, Object> map(MappingConfig mappingConfig, List<FieldDefinition> fieldDefs,
                                           String typeName) {
         String packageName = MapperUtils.getApiPackageName(mappingConfig);
-        String typeNameNormalized = MapperUtils.getClassNameWithPrefixAndSuffix(mappingConfig, typeName);
-
         Map<String, Object> dataModel = new HashMap<>();
         dataModel.put(PACKAGE, packageName);
         dataModel.put(IMPORTS, MapperUtils.getImportsForFieldResolvers(mappingConfig, packageName));
-        dataModel.put(CLASS_NAME, getClassName(typeNameNormalized));
+        dataModel.put(CLASS_NAME, getClassName(typeName));
+        String typeNameNormalized = MapperUtils.getClassNameWithPrefixAndSuffix(mappingConfig, typeName);
         dataModel.put(FIELDS, fieldDefs.stream()
                 .map(fieldDef -> mapFieldDefinition(mappingConfig, fieldDef, typeNameNormalized))
                 .collect(Collectors.toList()));

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenFieldsResolversTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenFieldsResolversTest.java
@@ -65,8 +65,8 @@ class GraphqlCodegenFieldsResolversTest {
 
         assertSameTrimmedContent(new File("src/test/resources/expected-classes/GithubAcceptTopicSuggestionPayloadTO.java.txt"),
                 getGeneratedFile(files, "GithubAcceptTopicSuggestionPayloadTO.java"));
-        assertSameTrimmedContent(new File("src/test/resources/expected-classes/GithubAcceptTopicSuggestionPayloadTOResolver.java.txt"),
-                getGeneratedFile(files, "GithubAcceptTopicSuggestionPayloadTOResolver.java"));
+        assertSameTrimmedContent(new File("src/test/resources/expected-classes/AcceptTopicSuggestionPayloadResolver.java.txt"),
+                getGeneratedFile(files, "AcceptTopicSuggestionPayloadResolver.java"));
     }
 
     private static File getGeneratedFile(File[] files, String fileName) throws FileNotFoundException {

--- a/src/test/resources/expected-classes/AcceptTopicSuggestionPayloadResolver.java.txt
+++ b/src/test/resources/expected-classes/AcceptTopicSuggestionPayloadResolver.java.txt
@@ -3,7 +3,7 @@ package com.github.graphql;
 import java.util.*;
 import graphql.schema.*;
 
-public interface GithubAcceptTopicSuggestionPayloadTOResolver {
+public interface AcceptTopicSuggestionPayloadResolver {
 
     GithubTopicTO topic(GithubAcceptTopicSuggestionPayloadTO githubAcceptTopicSuggestionPayloadTO, DataFetchingEnvironment env) throws Exception;
 


### PR DESCRIPTION
As discussed in the issue, FieldResolver class name should not contain modelNamePrefix/Suffix

Fixes #58 