### PR TITLE
Support extensions for all GraphQL types #81

### DIFF
--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/InputDefinitionToDataModelMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/InputDefinitionToDataModelMapper.java
@@ -1,9 +1,13 @@
 package com.kobylynskyi.graphql.codegen.mapper;
 
 import com.kobylynskyi.graphql.codegen.model.MappingConfig;
+import graphql.language.Document;
 import graphql.language.InputObjectTypeDefinition;
+import graphql.language.InputObjectTypeExtensionDefinition;
+import graphql.language.InputValueDefinition;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.kobylynskyi.graphql.codegen.model.DataModelFields.*;
@@ -20,21 +24,42 @@ public class InputDefinitionToDataModelMapper {
      *
      * @param mappingConfig  Global mapping configuration
      * @param typeDefinition GraphQL type definition
+     * @param document       GraphQL document
      * @return Freemarker data model of the GraphQL type
      */
-    public static Map<String, Object> map(MappingConfig mappingConfig, InputObjectTypeDefinition typeDefinition) {
-        Map<String, Object> dataModel = new HashMap<>();
+    public static Map<String, Object> map(MappingConfig mappingConfig, InputObjectTypeDefinition typeDefinition,
+                                          Document document) {
         String packageName = MapperUtils.getModelPackageName(mappingConfig);
+        List<InputValueDefinition> inputValueDefinitions = getInputValueDefinitions(typeDefinition, document);
+
+        Map<String, Object> dataModel = new HashMap<>();
         dataModel.put(PACKAGE, packageName);
         dataModel.put(IMPORTS, MapperUtils.getImports(mappingConfig, packageName));
         dataModel.put(CLASS_NAME, MapperUtils.getClassNameWithPrefixAndSuffix(mappingConfig, typeDefinition));
         dataModel.put(NAME, typeDefinition.getName());
-        dataModel.put(FIELDS, InputValueDefinitionToParameterMapper.map(mappingConfig, typeDefinition.getInputValueDefinitions(), typeDefinition.getName()));
+        dataModel.put(FIELDS, InputValueDefinitionToParameterMapper.map(mappingConfig, inputValueDefinitions, typeDefinition.getName()));
         dataModel.put(BUILDER, mappingConfig.getGenerateBuilder());
         dataModel.put(EQUALS_AND_HASH_CODE, mappingConfig.getGenerateEqualsAndHashCode());
         dataModel.put(TO_STRING, mappingConfig.getGenerateToString());
         dataModel.put(TO_STRING_ESCAPE_JSON, mappingConfig.getGenerateRequests());
         return dataModel;
+    }
+
+    /**
+     * Merge input value definitions from the definition and its extensions
+     *
+     * @param typeDefinition InputObjectTypeDefinition definition
+     * @param document       GraphQL document. Used to fetch all extensions of the same definition
+     * @return list of all input value definitions
+     */
+    private static List<InputValueDefinition> getInputValueDefinitions(InputObjectTypeDefinition typeDefinition,
+                                                                       Document document) {
+        List<InputValueDefinition> definitions = typeDefinition.getInputValueDefinitions();
+        MapperUtils.getDefinitionsOfType(document, InputObjectTypeExtensionDefinition.class, typeDefinition.getName())
+                .stream()
+                .map(InputObjectTypeDefinition::getInputValueDefinitions)
+                .forEach(definitions::addAll);
+        return definitions;
     }
 
 }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/InterfaceDefinitionToDataModelMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/InterfaceDefinitionToDataModelMapper.java
@@ -1,9 +1,13 @@
 package com.kobylynskyi.graphql.codegen.mapper;
 
 import com.kobylynskyi.graphql.codegen.model.MappingConfig;
+import graphql.language.Document;
+import graphql.language.FieldDefinition;
 import graphql.language.InterfaceTypeDefinition;
+import graphql.language.InterfaceTypeExtensionDefinition;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.kobylynskyi.graphql.codegen.model.DataModelFields.*;
@@ -20,16 +24,36 @@ public class InterfaceDefinitionToDataModelMapper {
      *
      * @param mappingConfig Global mapping configuration
      * @param typeDef       GraphQL interface definition
+     * @param document      GraphQL document
      * @return Freemarker data model of the GraphQL interface
      */
-    public static Map<String, Object> map(MappingConfig mappingConfig, InterfaceTypeDefinition typeDef) {
-        Map<String, Object> dataModel = new HashMap<>();
+    public static Map<String, Object> map(MappingConfig mappingConfig, InterfaceTypeDefinition typeDef,
+                                          Document document) {
         String packageName = MapperUtils.getModelPackageName(mappingConfig);
+        List<FieldDefinition> fieldDefinitions = getFieldDefinitions(typeDef, document);
+
+        Map<String, Object> dataModel = new HashMap<>();
         dataModel.put(PACKAGE, packageName);
         dataModel.put(IMPORTS, MapperUtils.getImports(mappingConfig, packageName));
         dataModel.put(CLASS_NAME, MapperUtils.getClassNameWithPrefixAndSuffix(mappingConfig, typeDef));
-        dataModel.put(FIELDS, FieldDefinitionToParameterMapper.mapFields(mappingConfig, typeDef.getFieldDefinitions(), typeDef.getName()));
+        dataModel.put(FIELDS, FieldDefinitionToParameterMapper.mapFields(mappingConfig, fieldDefinitions, typeDef.getName()));
         return dataModel;
+    }
+
+    /**
+     * Merge interface field definitions from the definition and its extensions
+     *
+     * @param typeDefinition InterfaceTypeDefinition definition
+     * @param document       GraphQL document. Used to fetch all extensions of the same definition
+     * @return list of all interface field definitions
+     */
+    private static List<FieldDefinition> getFieldDefinitions(InterfaceTypeDefinition typeDefinition,
+                                                             Document document) {
+        List<FieldDefinition> definitions = typeDefinition.getFieldDefinitions();
+        MapperUtils.getDefinitionsOfType(document, InterfaceTypeExtensionDefinition.class, typeDefinition.getName()).stream()
+                .map(InterfaceTypeDefinition::getFieldDefinitions)
+                .forEach(definitions::addAll);
+        return definitions;
     }
 
 }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/model/DefinitionTypeDeterminer.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/model/DefinitionTypeDeterminer.java
@@ -6,27 +6,35 @@ import lombok.NonNull;
 
 public class DefinitionTypeDeterminer {
 
-    public static GraphqlDefinitionType determine(@NonNull Definition definition) {
-        if (definition instanceof ObjectTypeDefinition) {
+    /**
+     * Determine the type of GraphQL definition.
+     * Comparing using <code>.getClass()</code> in order to ignore subclasses (ExtensionDefinitions in our case)
+     *
+     * @param definition GraphQL definition
+     * @return one of {@link GraphqlDefinitionType}
+     */
+    public static GraphqlDefinitionType determine(@NonNull Definition<?> definition) {
+        Class<?> definitionClass = definition.getClass();
+        if (definitionClass.equals(ObjectTypeDefinition.class)) {
             ObjectTypeDefinition typeDef = (ObjectTypeDefinition) definition;
             if (Utils.isGraphqlOperation(typeDef.getName())) {
                 return GraphqlDefinitionType.OPERATION;
             } else {
                 return GraphqlDefinitionType.TYPE;
             }
-        } else if (definition instanceof EnumTypeDefinition) {
+        } else if (definitionClass.equals(EnumTypeDefinition.class)) {
             return GraphqlDefinitionType.ENUM;
-        } else if (definition instanceof InputObjectTypeDefinition) {
+        } else if (definitionClass.equals(InputObjectTypeDefinition.class)) {
             return GraphqlDefinitionType.INPUT;
-        } else if (definition instanceof SchemaDefinition) {
+        } else if (definitionClass.equals(SchemaDefinition.class)) {
             return GraphqlDefinitionType.SCHEMA;
-        } else if (definition instanceof UnionTypeDefinition) {
+        } else if (definitionClass.equals(UnionTypeDefinition.class)) {
             return GraphqlDefinitionType.UNION;
-        } else if (definition instanceof ScalarTypeDefinition) {
+        } else if (definitionClass.equals(ScalarTypeDefinition.class)) {
             return GraphqlDefinitionType.SCALAR;
-        } else if (definition instanceof InterfaceTypeDefinition) {
+        } else if (definitionClass.equals(InterfaceTypeDefinition.class)) {
             return GraphqlDefinitionType.INTERFACE;
-        } else if (definition instanceof DirectiveDefinition) {
+        } else if (definitionClass.equals(DirectiveDefinition.class)) {
             return GraphqlDefinitionType.DIRECTIVE;
         } else {
             throw new UnsupportedGraphqlDefinitionException(definition);

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenExtendTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphqlCodegenExtendTest.java
@@ -1,0 +1,83 @@
+package com.kobylynskyi.graphql.codegen;
+
+import com.kobylynskyi.graphql.codegen.model.MappingConfig;
+import com.kobylynskyi.graphql.codegen.supplier.SchemaFinder;
+import com.kobylynskyi.graphql.codegen.utils.Utils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GraphqlCodegenExtendTest {
+
+    private final File outputBuildDir = new File("build/generated");
+    private final File outputJavaClassesDir = new File("build/generated");
+    private final MappingConfig mappingConfig = new MappingConfig();
+    private final SchemaFinder schemaFinder = new SchemaFinder(Paths.get("src/test/resources"));
+
+    @BeforeEach
+    void init() throws IOException {
+        schemaFinder.setIncludePattern("extend.*\\.graphqls");
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        Utils.deleteDir(new File("build/generated"));
+    }
+
+    @Test
+    void generateServerSideClasses() throws Exception {
+        new GraphqlCodegen(schemaFinder.findSchemas(), outputBuildDir, mappingConfig).generate();
+
+        File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
+        Set<String> generatedFileNames = Arrays.stream(files).map(File::getName).collect(toSet());
+        assertEquals(new HashSet<>(asList("Mutation.java", "Query.java",
+                "EventsQuery.java", "AssetsQuery.java",
+                "CreateEventMutation.java", "CreateAssetMutation.java",
+                "Event.java", "Asset.java", "EventInput.java", "AssetInput.java",
+                "Node.java", "Status.java", "PinnableItem.java")), generatedFileNames);
+
+        for (File file : files) {
+            assertSameTrimmedContent(
+                    new File(String.format("src/test/resources/expected-classes/extend/%s.txt", file.getName())),
+                    file);
+        }
+    }
+
+    @Test
+    void generateClientSideClasses() throws Exception {
+        mappingConfig.setGenerateApis(false);
+        mappingConfig.setGenerateRequests(true);
+        new GraphqlCodegen(schemaFinder.findSchemas(), outputBuildDir, mappingConfig).generate();
+
+        File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
+
+        File eventResponseProjectionFile = Arrays.stream(files)
+                .filter(file -> file.getName().equalsIgnoreCase("EventResponseProjection.java")).findFirst()
+                .orElseThrow(FileNotFoundException::new);
+        assertSameTrimmedContent(
+                new File("src/test/resources/expected-classes/extend/request/EventResponseProjection.java.txt"),
+                eventResponseProjectionFile);
+
+        File assetResponseProjectionFile = Arrays.stream(files)
+                .filter(file -> file.getName().equalsIgnoreCase("AssetResponseProjection.java")).findFirst()
+                .orElseThrow(FileNotFoundException::new);
+        assertSameTrimmedContent(
+                new File("src/test/resources/expected-classes/extend/request/AssetResponseProjection.java.txt"),
+                assetResponseProjectionFile);
+    }
+
+}

--- a/src/test/resources/expected-classes/extend/Asset.java.txt
+++ b/src/test/resources/expected-classes/extend/Asset.java.txt
@@ -1,0 +1,89 @@
+import java.util.*;
+
+public class Asset implements PinnableItem, Node{
+
+    @javax.validation.constraints.NotNull
+    private String name;
+    @javax.validation.constraints.NotNull
+    private Status status;
+    @javax.validation.constraints.NotNull
+    private String id;
+    private String createdBy;
+
+    public Asset() {
+    }
+
+    public Asset(String name, Status status, String id, String createdBy) {
+        this.name = name;
+        this.status = status;
+        this.id = id;
+        this.createdBy = createdBy;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+
+
+    public static class Builder {
+
+        private String name;
+        private Status status;
+        private String id;
+        private String createdBy;
+
+        public Builder() {
+        }
+
+        public Builder setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder setStatus(Status status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder setId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setCreatedBy(String createdBy) {
+            this.createdBy = createdBy;
+            return this;
+        }
+
+
+        public Asset build() {
+            return new Asset(name, status, id, createdBy);
+        }
+
+    }
+}

--- a/src/test/resources/expected-classes/extend/AssetInput.java.txt
+++ b/src/test/resources/expected-classes/extend/AssetInput.java.txt
@@ -1,0 +1,42 @@
+import java.util.*;
+
+public class AssetInput {
+
+    @javax.validation.constraints.NotNull
+    private String name;
+
+    public AssetInput() {
+    }
+
+    public AssetInput(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+
+    public static class Builder {
+
+        private String name;
+
+        public Builder() {
+        }
+
+        public Builder setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+
+        public AssetInput build() {
+            return new AssetInput(name);
+        }
+
+    }
+}

--- a/src/test/resources/expected-classes/extend/AssetsQuery.java.txt
+++ b/src/test/resources/expected-classes/extend/AssetsQuery.java.txt
@@ -1,0 +1,8 @@
+import java.util.*;
+
+public interface AssetsQuery {
+
+    @javax.validation.constraints.NotNull
+    Collection<Asset> assets() throws Exception;
+
+}

--- a/src/test/resources/expected-classes/extend/CreateAssetMutation.java.txt
+++ b/src/test/resources/expected-classes/extend/CreateAssetMutation.java.txt
@@ -1,0 +1,8 @@
+import java.util.*;
+
+public interface CreateAssetMutation {
+
+    @javax.validation.constraints.NotNull
+    Asset createAsset(AssetInput input) throws Exception;
+
+}

--- a/src/test/resources/expected-classes/extend/CreateEventMutation.java.txt
+++ b/src/test/resources/expected-classes/extend/CreateEventMutation.java.txt
@@ -1,0 +1,8 @@
+import java.util.*;
+
+public interface CreateEventMutation {
+
+    @javax.validation.constraints.NotNull
+    Event createEvent(EventInput input) throws Exception;
+
+}

--- a/src/test/resources/expected-classes/extend/Event.java.txt
+++ b/src/test/resources/expected-classes/extend/Event.java.txt
@@ -1,0 +1,105 @@
+import java.util.*;
+
+public class Event implements PinnableItem, Node{
+
+    @javax.validation.constraints.NotNull
+    private Status status;
+    @javax.validation.constraints.NotNull
+    private String createdDateTime;
+    @javax.validation.constraints.NotNull
+    private String id;
+    private String createdBy;
+    @javax.validation.constraints.NotNull
+    private Collection<Asset> assets;
+
+    public Event() {
+    }
+
+    public Event(Status status, String createdDateTime, String id, String createdBy, Collection<Asset> assets) {
+        this.status = status;
+        this.createdDateTime = createdDateTime;
+        this.id = id;
+        this.createdBy = createdBy;
+        this.assets = assets;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getCreatedDateTime() {
+        return createdDateTime;
+    }
+    public void setCreatedDateTime(String createdDateTime) {
+        this.createdDateTime = createdDateTime;
+    }
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Collection<Asset> getAssets() {
+        return assets;
+    }
+    public void setAssets(Collection<Asset> assets) {
+        this.assets = assets;
+    }
+
+
+
+    public static class Builder {
+
+        private Status status;
+        private String createdDateTime;
+        private String id;
+        private String createdBy;
+        private Collection<Asset> assets;
+
+        public Builder() {
+        }
+
+        public Builder setStatus(Status status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder setCreatedDateTime(String createdDateTime) {
+            this.createdDateTime = createdDateTime;
+            return this;
+        }
+
+        public Builder setId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setCreatedBy(String createdBy) {
+            this.createdBy = createdBy;
+            return this;
+        }
+
+        public Builder setAssets(Collection<Asset> assets) {
+            this.assets = assets;
+            return this;
+        }
+
+
+        public Event build() {
+            return new Event(status, createdDateTime, id, createdBy, assets);
+        }
+
+    }
+}

--- a/src/test/resources/expected-classes/extend/EventInput.java.txt
+++ b/src/test/resources/expected-classes/extend/EventInput.java.txt
@@ -1,0 +1,58 @@
+import java.util.*;
+
+public class EventInput {
+
+    @javax.validation.constraints.NotNull
+    private Status status;
+    @javax.validation.constraints.NotNull
+    private Collection<AssetInput> assets;
+
+    public EventInput() {
+    }
+
+    public EventInput(Status status, Collection<AssetInput> assets) {
+        this.status = status;
+        this.assets = assets;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public Collection<AssetInput> getAssets() {
+        return assets;
+    }
+    public void setAssets(Collection<AssetInput> assets) {
+        this.assets = assets;
+    }
+
+
+
+    public static class Builder {
+
+        private Status status;
+        private Collection<AssetInput> assets;
+
+        public Builder() {
+        }
+
+        public Builder setStatus(Status status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder setAssets(Collection<AssetInput> assets) {
+            this.assets = assets;
+            return this;
+        }
+
+
+        public EventInput build() {
+            return new EventInput(status, assets);
+        }
+
+    }
+}

--- a/src/test/resources/expected-classes/extend/EventsQuery.java.txt
+++ b/src/test/resources/expected-classes/extend/EventsQuery.java.txt
@@ -1,0 +1,8 @@
+import java.util.*;
+
+public interface EventsQuery {
+
+    @javax.validation.constraints.NotNull
+    Collection<Event> events() throws Exception;
+
+}

--- a/src/test/resources/expected-classes/extend/Mutation.java.txt
+++ b/src/test/resources/expected-classes/extend/Mutation.java.txt
@@ -1,0 +1,11 @@
+import java.util.*;
+
+public interface Mutation {
+
+    @javax.validation.constraints.NotNull
+    Event createEvent(EventInput input) throws Exception;
+
+    @javax.validation.constraints.NotNull
+    Asset createAsset(AssetInput input) throws Exception;
+
+}

--- a/src/test/resources/expected-classes/extend/Node.java.txt
+++ b/src/test/resources/expected-classes/extend/Node.java.txt
@@ -1,0 +1,9 @@
+import java.util.*;
+
+public interface Node {
+
+    String getId();
+
+    String getCreatedBy();
+
+}

--- a/src/test/resources/expected-classes/extend/PinnableItem.java.txt
+++ b/src/test/resources/expected-classes/extend/PinnableItem.java.txt
@@ -1,0 +1,5 @@
+import java.util.*;
+
+public interface PinnableItem {
+
+}

--- a/src/test/resources/expected-classes/extend/Query.java.txt
+++ b/src/test/resources/expected-classes/extend/Query.java.txt
@@ -1,0 +1,11 @@
+import java.util.*;
+
+public interface Query {
+
+    @javax.validation.constraints.NotNull
+    Collection<Event> events() throws Exception;
+
+    @javax.validation.constraints.NotNull
+    Collection<Asset> assets() throws Exception;
+
+}

--- a/src/test/resources/expected-classes/extend/Status.java.txt
+++ b/src/test/resources/expected-classes/extend/Status.java.txt
@@ -1,0 +1,7 @@
+public enum Status {
+
+    CREATED,
+    IN_PROGRESS,
+    ASSIGNED
+
+}

--- a/src/test/resources/expected-classes/extend/request/AssetResponseProjection.java.txt
+++ b/src/test/resources/expected-classes/extend/request/AssetResponseProjection.java.txt
@@ -1,0 +1,46 @@
+import java.util.*;
+import com.kobylynskyi.graphql.codegen.model.graphql.*;
+
+public class AssetResponseProjection implements GraphQLResponseProjection {
+
+    private Map<String, Object> fields = new LinkedHashMap<>();
+
+    public AssetResponseProjection() {
+    }
+
+    public AssetResponseProjection name() {
+        fields.put("name", null);
+        return this;
+    }
+
+    public AssetResponseProjection status() {
+        fields.put("status", null);
+        return this;
+    }
+
+    public AssetResponseProjection id() {
+        fields.put("id", null);
+        return this;
+    }
+
+    public AssetResponseProjection createdBy() {
+        fields.put("createdBy", null);
+        return this;
+    }
+
+
+    @Override
+    public String toString() {
+        if (fields.isEmpty()) {
+            return "";
+        }
+        StringJoiner joiner = new StringJoiner(" ", "{ ", " }");
+        for (Map.Entry<String, Object> property : fields.entrySet()) {
+            joiner.add(property.getKey());
+            if (property.getValue() != null) {
+                joiner.add(" ").add(property.getValue().toString());
+            }
+        }
+        return joiner.toString();
+    }
+}

--- a/src/test/resources/expected-classes/extend/request/EventResponseProjection.java.txt
+++ b/src/test/resources/expected-classes/extend/request/EventResponseProjection.java.txt
@@ -1,0 +1,51 @@
+import java.util.*;
+import com.kobylynskyi.graphql.codegen.model.graphql.*;
+
+public class EventResponseProjection implements GraphQLResponseProjection {
+
+    private Map<String, Object> fields = new LinkedHashMap<>();
+
+    public EventResponseProjection() {
+    }
+
+    public EventResponseProjection status() {
+        fields.put("status", null);
+        return this;
+    }
+
+    public EventResponseProjection createdDateTime() {
+        fields.put("createdDateTime", null);
+        return this;
+    }
+
+    public EventResponseProjection id() {
+        fields.put("id", null);
+        return this;
+    }
+
+    public EventResponseProjection createdBy() {
+        fields.put("createdBy", null);
+        return this;
+    }
+
+    public EventResponseProjection assets(AssetResponseProjection subProjection) {
+        fields.put("assets", subProjection);
+        return this;
+    }
+
+
+    @Override
+    public String toString() {
+        if (fields.isEmpty()) {
+            return "";
+        }
+        StringJoiner joiner = new StringJoiner(" ", "{ ", " }");
+        for (Map.Entry<String, Object> property : fields.entrySet()) {
+            joiner.add(property.getKey());
+            if (property.getValue() != null) {
+                joiner.add(" ").add(property.getValue().toString());
+            }
+        }
+        return joiner.toString();
+    }
+}

--- a/src/test/resources/schemas/extend1.graphqls
+++ b/src/test/resources/schemas/extend1.graphqls
@@ -1,0 +1,35 @@
+# A GraphQL schema provides a root type for each kind of operation.
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    events: [Event!]
+}
+
+type Mutation {
+    createEvent(input: EventInput!): Event!
+}
+
+type Event implements Node {
+    status: Status!
+    createdDateTime: DateTime!
+}
+
+input EventInput {
+    status: Status!
+}
+
+enum Status {
+    CREATED
+    IN_PROGRESS
+}
+
+interface Node {
+    id: ID!
+}
+
+union PinnableItem = Event
+
+scalar DateTime

--- a/src/test/resources/schemas/extend2.graphqls
+++ b/src/test/resources/schemas/extend2.graphqls
@@ -1,0 +1,43 @@
+# A GraphQL schema provides a root type for each kind of operation.
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+extend type Query {
+    assets: [Asset!]
+}
+
+extend type Mutation {
+    createAsset(input: AssetInput!): Asset!
+}
+
+type Asset implements Node {
+    name: String!
+    status: Status!
+}
+
+input AssetInput {
+    name: String!
+}
+
+extend type Event {
+    assets: [Asset!]
+}
+
+extend input EventInput {
+    assets: [AssetInput!]
+}
+
+extend enum Status {
+    ASSIGNED
+}
+
+extend interface Node {
+    createdBy: String
+}
+
+extend union PinnableItem = Asset
+
+
+extend scalar DateTime @javaType(name: "java.util.Date")


### PR DESCRIPTION
It is the first part of the changes related to extensions.

As suggested by @joffrey-bion, upcoming changes will include:
* Config `generateExtensionFieldsResolvers`
* Config `fieldsWithoutResolvers`