### PR TITLE
Fix Gradle task inputs

### DIFF
--- a/plugins/gradle/graphql-java-codegen-gradle-plugin/src/main/java/io/github/kobylynskyi/graphql/codegen/gradle/SchemaFinderConfig.java
+++ b/plugins/gradle/graphql-java-codegen-gradle-plugin/src/main/java/io/github/kobylynskyi/graphql/codegen/gradle/SchemaFinderConfig.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 
@@ -20,7 +19,9 @@ public class SchemaFinderConfig {
 
     private Set<String> excludedFiles = Collections.emptySet();
 
-    @InputFile
+    // This should not be replaced by @InputDirectory, because some files in this directory may not be schemas.
+    // We only know the actual list of schema files to check after running the SchemaFinder, so @InputFiles is over there.
+    @Input
     @Optional
     public String getRootDir() {
         return rootDir;


### PR DESCRIPTION
The intermediate getter for schema paths is now public so that it can be part of the inputs.
This way, whether the schemas are found via explicit paths or SchemaFinder or the default config doesn't matter, changes are picked up no matter what.

If no changes are made, the task is correctly considered UP-TO_DATE.

Resolves:
https://github.com/kobylynskyi/graphql-java-codegen/issues/83