### PR TITLE
Setup build files for releasing plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Please follow the steps below in order to make the changes:
 
 ### For the sbt plugin
 
-1. Publish the core library locally with `./gradlew publishIvyPublicationToIvyRepository`
+1. Publish the core library locally. See the instructions at the bottom of build.gradle discussing the necessary process due to Gradle bug
 2. Publish the sbt plugin locally
    ```shell script
    cd plugins/sbt

--- a/build.gradle
+++ b/build.gradle
@@ -127,8 +127,12 @@ publishing {
         }
         ivy {
             url "${System.properties['user.home']}/.ivy2/local"
-            // use this layout pattern to work around https://github.com/gradle/gradle/issues/12911
             patternLayout {
+                // Need to publish twice due to a Gradle bug https://github.com/gradle/gradle/issues/12911
+                // First uncomment the 'layout' line below and comment out the 'artifact' and 'ivy' lines and run `./gradlew publishIvyPublicationToIvyRepository`
+                // Then restore the code to its original state and run `./gradlew publishIvyPublicationToIvyRepository` again
+
+                // layout "ivy"
                 artifact '[organisation]/[module]/[revision]/[ext]s/[artifact](-[classifier])(.[ext])'
                 ivy '[organisation]/[module]/[revision]/[artifact]/[artifact](-[classifier])(.[ext])'
             }

--- a/plugins/sbt/build.sbt
+++ b/plugins/sbt/build.sbt
@@ -4,9 +4,7 @@ name := "sbt-graphql-java-codegen"
 organization := "io.github.kobylynskyi"
 description := "Plugin for generating Java code based on GraphQL schema"
 
-version := "1.6.1-SNAPSHOT"
-
-libraryDependencies += "io.github.kobylynskyi" % "graphql-java-codegen" % "1.6.1-SNAPSHOT"
+libraryDependencies += "io.github.kobylynskyi" % "graphql-java-codegen" % version.value
 
 enablePlugins(SbtPlugin)
 scriptedLaunchOpts := { scriptedLaunchOpts.value ++
@@ -15,3 +13,5 @@ scriptedLaunchOpts := { scriptedLaunchOpts.value ++
 scriptedBufferLog := false
 
 licenses := Seq("MIT License" -> url("https://github.com/kobylynskyi/graphql-java-codegen/blob/master/LICENSE.md"))
+bintrayOrganization := None
+bintrayRepository := "sbt-plugins"

--- a/plugins/sbt/project/plugins.sbt
+++ b/plugins/sbt/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")

--- a/plugins/sbt/version.sbt
+++ b/plugins/sbt/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "1.6.1-SNAPSHOT"


### PR DESCRIPTION
The plugin should be ready to be released after https://github.com/kobylynskyi/graphql-java-codegen/pull/127 is merged and the account is setup as described in [the sbt docs](https://www.scala-sbt.org/1.x/docs/Bintray-For-Plugins.html)

I believe the steps for each release will simply be:
* Release core library (the sbt plugin depends on the core library with same version number)
* Run `sbt publish`

I'm not quite sure how to test that this is setup correctly. I guess we will find out the first time we try