### PR TITLE
Support of HTTP Query String serialization #154

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:1.18.12"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.5.1"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.5.1"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.5.1"
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
 }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/model/graphql/GraphQLRequest.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/model/graphql/GraphQLRequest.java
@@ -25,8 +25,32 @@ public class GraphQLRequest {
         return responseProjection;
     }
 
+    /**
+     * @deprecated Not intended for use and will be removed in the next version.
+     * Please use one of: {@link #toHttpJsonBody} or {@link #toQueryString}
+     */
     @Override
+    @Deprecated
     public String toString() {
-        return GraphQLRequestSerializer.serialize(this);
+        return toHttpJsonBody();
+    }
+
+    /**
+     * Serializes GraphQL request to be used as HTTP JSON body
+     * according to https://graphql.org/learn/serving-over-http specifications
+     * 
+     * @return the serialized request
+     */
+    public String toHttpJsonBody() {
+        return GraphQLRequestSerializer.toHttpJsonBody(this);
+    }
+
+    /**
+     * Serializes GraphQL request as raw query string
+     * 
+     * @return the serialized request
+     */
+    public String toQueryString() {
+        return GraphQLRequestSerializer.toQueryString(this);
     }
 }


### PR DESCRIPTION
* Support of HTTP Query String serialization #154

* Add junit-jupiter-params as test dependency + parameterized tests for GraphQLRequestSerializer