### PR TITLE
Update gradle plugin readme

### DIFF
--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -92,9 +92,9 @@ sourceSets {
 }
 
 // Add generated sources to your project source sets:
-val check: DefaultTask by tasks
-val graphqlCodegen: DefaultTask by tasks
-check.dependsOn(graphqlCodegen)    
+tasks.named<JavaCompile>("compileJava") {
+    dependsOn("graphqlCodegen")
+}
 ```
 
 


### PR DESCRIPTION
In my own project we migrated from Groovie to Kotlin gradle files, and, sadly, info from readme file did not work. This is the way we can add graphql generating task to java compile in the project when we use kotlin in gradle files. 

Cheers