### PR TITLE
Tweaked project dependencies for Maven plugin to avoid CVSS SNYK-JAVA…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ test {
 
 codeCoverageReport.dependsOn test
 
+compileJava.options.encoding = "UTF-8"
+compileTestJava.options.encoding = "UTF-8"
 
 java {
     withJavadocJar()

--- a/plugins/maven/graphql-java-codegen-maven-plugin/pom.xml
+++ b/plugins/maven/graphql-java-codegen-maven-plugin/pom.xml
@@ -83,6 +83,17 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${version.maven-core}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven.shared</groupId>
+                    <artifactId>maven-shared-utils</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-shared-utils</artifactId>
+            <version>3.3.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -169,6 +180,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${version.maven-javadoc-plugin}</version>
                 <configuration>
+                    <source>1.8</source>
                     <encoding>UTF-8</encoding>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Fix for the Severe vulnerability in the Maven plugin shared library, per Issue reported.

https://github.com/kobylynskyi/graphql-java-codegen/issues/326 

This contains a fix that builds and passes tests. When's the next release? :-)