### PR TITLE
fix ParameterInput toString bug

### DIFF
--- a/src/main/resources/templates/kotlin-lang/kotlinClassGraphqlParametrizedInput.ftl
+++ b/src/main/resources/templates/kotlin-lang/kotlinClassGraphqlParametrizedInput.ftl
@@ -3,6 +3,7 @@ package ${package}
 
 </#if>
 import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLParametrizedInput
+import java.util.StringJoiner
 <#if javaDoc?has_content>
 /**
 <#list javaDoc as javaDocLine>
@@ -20,7 +21,9 @@ import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLParametrizedInput
 @${annotation}
 </#list>
 <#if !fields?has_content>
-class ${className}() : GraphQLParametrizedInput
+class ${className}() : GraphQLParametrizedInput {
+    override fun toString(): String = "()"
+}
 <#else>
 data class ${className}(
 <#if fields?has_content>
@@ -32,5 +35,20 @@ data class ${className}(
     </#list>val ${field.name}: ${field.type}<#if field.defaultValue?has_content> = ${field.defaultValue}</#if><#if field_has_next>,</#if>
 </#list>
 </#if>
-) : GraphQLParametrizedInput
+) : GraphQLParametrizedInput {
+
+    override fun toString(): String {
+        val joiner = StringJoiner(", ", "( ", " )")
+        <#list fields as field>
+        <#if field.type?ends_with("?")>
+        if (${field.name} != null) {
+            joiner.add("${field.originalName}: " + GraphQLRequestSerializer.getEntry(${field.name}))
+        }
+        <#else>
+        joiner.add("${field.originalName}: " + GraphQLRequestSerializer.getEntry(${field.name}))
+        </#if>
+        </#list>
+        return joiner.toString()
+    }
+}
 </#if>

--- a/src/main/resources/templates/kotlin-lang/kotlinClassGraphqlType.ftl
+++ b/src/main/resources/templates/kotlin-lang/kotlinClassGraphqlType.ftl
@@ -87,7 +87,7 @@ data class ${className}(
         <#if toStringForRequest>
             joiner.add("${field.originalName}: " + GraphQLRequestSerializer.getEntry(${field.name}))
         <#else>
-        <#if field.type == "String">
+        <#if field.type == "String?">
             joiner.add("${field.originalName}: \"${field.name}\"")
         <#else>
             joiner.add(${field.originalName}: ${field.name}")

--- a/src/main/resources/templates/scala-lang/scalaClassGraphqlParametrizedInput.ftl
+++ b/src/main/resources/templates/scala-lang/scalaClassGraphqlParametrizedInput.ftl
@@ -54,9 +54,13 @@ case class ${className}(
 ) extends GraphQLParametrizedInput {
 
     override def toString(): String = {<#--There is no Option[Seq[T]]-->
+    <#if fields?has_content>
         Seq(<#list fields as field><#assign getMethod = ".get"><#assign asJava = ".asJava">
             <#if MapperUtil.isScalaPrimitive(field.type)>"${field.originalName}: " + GraphQLRequestSerializer.getEntry(${field.name})<#if field_has_next>,</#if><#elseif MapperUtil.isScalaOption(field.type)>if (${field.name}.isDefined) "${field.originalName}: " + GraphQLRequestSerializer.getEntry(${field.name}${getMethod}) else ""<#if field_has_next>,</#if><#else>if (${field.name} != null)<#if MapperUtil.isScalaCollection(field.type)> "${field.originalName}: " + GraphQLRequestSerializer.getEntry(${field.name}${asJava}) else ""<#if field_has_next>,</#if><#else> "${field.originalName}: " + GraphQLRequestSerializer.getEntry(${field.name}) else ""<#if field_has_next>,</#if></#if></#if></#list>
         ).filter(_ != "").mkString("(", ",", ")")
+    <#else>
+        "()"
+    </#if>
     }
 
 }

--- a/src/main/resources/templates/scala-lang/scalaClassGraphqlParametrizedInput.ftl
+++ b/src/main/resources/templates/scala-lang/scalaClassGraphqlParametrizedInput.ftl
@@ -4,6 +4,7 @@ package ${package}
 
 </#if>
 import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLParametrizedInput
+import scala.collection.JavaConverters._
 <#if fields?has_content>
     <#if enumImportItSelfInScala?has_content>
         <#list fields as field>
@@ -47,7 +48,15 @@ case class ${className}(
     <#list field.annotations as annotation>
     @${annotation}
     </#list>
-    ${field.name}: ${field.type}<#if field.defaultValue?has_content> = <#if MapperUtil.isScalaOption(field.type)><#if field.defaultValue!= "null">Some(${field.defaultValue})<#else>None</#if><#else>${field.defaultValue}</#if></#if><#if field_has_next>,</#if>
+    ${field.name}: ${field.type}<#if field.defaultValue?has_content> = <#if MapperUtil.isScalaOption(field.type)><#if field.defaultValue != "null">Some(${field.defaultValue})<#else>None</#if><#else>${field.defaultValue}</#if></#if><#if field_has_next>,</#if>
 </#list>
 </#if>
-) extends GraphQLParametrizedInput
+) extends GraphQLParametrizedInput {
+
+    override def toString(): String = {<#--There is no Option[Seq[T]]-->
+        Seq(<#list fields as field><#assign getMethod = ".get"><#assign asJava = ".asJava">
+            <#if MapperUtil.isScalaPrimitive(field.type)>"${field.originalName}: " + GraphQLRequestSerializer.getEntry(${field.name})<#if field_has_next>,</#if><#elseif MapperUtil.isScalaOption(field.type)>if (${field.name}.isDefined) "${field.originalName}: " + GraphQLRequestSerializer.getEntry(${field.name}${getMethod}) else ""<#if field_has_next>,</#if><#else>if (${field.name} != null)<#if MapperUtil.isScalaCollection(field.type)> "${field.originalName}: " + GraphQLRequestSerializer.getEntry(${field.name}${asJava}) else ""<#if field_has_next>,</#if><#else> "${field.originalName}: " + GraphQLRequestSerializer.getEntry(${field.name}) else ""<#if field_has_next>,</#if></#if></#if></#list>
+        ).filter(_ != "").mkString("(", ",", ")")
+    }
+
+}

--- a/src/main/resources/templates/scala-lang/scalaClassGraphqlType.ftl
+++ b/src/main/resources/templates/scala-lang/scalaClassGraphqlType.ftl
@@ -77,18 +77,18 @@ case class ${className}(
 <#list field.annotations as annotation>
     @${annotation}
 </#list>
-    <#if parentInterfaces?has_content><#list parentInterfaces as parent><#if parent == field.name>override </#if></#list></#if><#if !immutableModels>var <#else><#if parentInterfaces?has_content><#list parentInterfaces as parent><#if parent == field.name>val </#if></#list></#if></#if>${field.name}: ${field.type}<#if field.defaultValue?has_content> = <#if field.type?starts_with("Option[")><#if field.defaultValue!= "null">Some(${field.defaultValue})<#else>None</#if><#else>${field.defaultValue}</#if></#if><#if field_has_next>,</#if>
+    <#if parentInterfaces?has_content><#list parentInterfaces as parent><#if parent == field.name>override </#if></#list></#if><#if !immutableModels>var <#else><#if parentInterfaces?has_content><#list parentInterfaces as parent><#if parent == field.name>val </#if></#list></#if></#if>${field.name}: ${field.type}<#if field.defaultValue?has_content> = <#if MapperUtil.isScalaOption(field.type)><#if field.defaultValue != "null">Some(${field.defaultValue})<#else>None</#if><#else>${field.defaultValue}</#if></#if><#if field_has_next>,</#if>
 </#list>
 </#if>
 )<#if implements?has_content> extends <#list implements as interface>${interface}<#if interface_has_next> with </#if></#list></#if> {
 
 <#if toString>
     override def toString(): String = {
-    <#if fields?has_content>
+    <#if fields?has_content><#-- When you modify it, copy it out and make sure it is one line after modification, There is no Option[Seq[T]]. -->
         Seq(<#list fields as field><#assign getMethod = ""><#assign asJava = ""><#if MapperUtil.isScalaOption(field.type)><#assign getMethod = ".get"></#if><#if MapperUtil.isScalaCollection(field.type)><#assign asJava = ".asJava"></#if>
             <#if MapperUtil.isScalaPrimitive(field.type)><#if toStringForRequest>"${field.originalName}: " + GraphQLRequestSerializer.getEntry(${field.name}<#if field.serializeUsingObjectMapper>, true</#if>)<#else>"${field.originalName}: " + ${field.name}</#if><#else><#if MapperUtil.isScalaOption(field.type)>if (${field.name}.isDefined) <#else>if (${field.name} != null) </#if><#if toStringForRequest>"${field.originalName}: " + GraphQLRequestSerializer.getEntry(${field.name}${getMethod}${asJava}<#if field.serializeUsingObjectMapper>, true</#if>)<#else><#if field.type == "String"> "${field.originalName}: \"${field.name}\"" <#else> "${field.originalName}: ${field.name}"</#if></#if> else ""</#if><#if field_has_next>,</#if></#list>
         ).filter(_ != "").mkString("{", ",", "}")
-        <#else>
+        <#else><#--Keep it on one line to make sure the code style remains the same-->
         "{}"
     </#if>
     }

--- a/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenRestrictedWordsAndParameterInputTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenRestrictedWordsAndParameterInputTest.java
@@ -1,0 +1,62 @@
+package com.kobylynskyi.graphql.codegen.kotlin;
+
+import com.kobylynskyi.graphql.codegen.TestUtils;
+import com.kobylynskyi.graphql.codegen.model.GeneratedLanguage;
+import com.kobylynskyi.graphql.codegen.model.MappingConfig;
+import com.kobylynskyi.graphql.codegen.utils.Utils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GraphQLCodegenRestrictedWordsAndParameterInputTest {
+
+    private final MappingConfig mappingConfig = new MappingConfig();
+
+    private final File outputBuildDir = new File("build/generated");
+    private final File outputJavaClassesDir = new File("build/generated/com/kobylynskyi/graphql/codegen/prot");
+
+    @AfterEach
+    void cleanup() {
+        Utils.deleteDir(outputBuildDir);
+    }
+
+    @Test
+    void generate() throws Exception {
+        mappingConfig.setGeneratedLanguage(GeneratedLanguage.KOTLIN);
+        mappingConfig.setPackageName("com.kobylynskyi.graphql.codegen.prot");
+        mappingConfig.setGenerateClient(true);
+        mappingConfig.setGenerateBuilder(true);
+        mappingConfig.setGenerateEqualsAndHashCode(true);
+        mappingConfig.setGenerateToString(true);
+        mappingConfig.setGenerateModelsForRootTypes(true);
+        mappingConfig.setApiNameSuffix("API");
+
+        new KotlinGraphQLCodegen(singletonList("src/test/resources/schemas/kt/restricted-words.graphqls"),
+                outputBuildDir, mappingConfig, TestUtils.getStaticGeneratedInfo()).generate();
+
+        File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
+        List<?> filters = Arrays.asList("Char.kt", "CharResponseProjection.kt", "FunQueryRequest.kt", "FunQueryResponse.kt", "QueryFunParametrizedInput.kt",
+                "Super.kt", "TestEnum.kt", "WhenQueryAPI.kt");
+        List<String> generatedFileNames = Arrays.stream(files).map(File::getName).filter(f -> filters.contains(f)).sorted().collect(toList());
+        assertEquals(Arrays.asList("Char.kt", "CharResponseProjection.kt", "FunQueryRequest.kt", "FunQueryResponse.kt", "QueryFunParametrizedInput.kt",
+                "Super.kt", "TestEnum.kt", "WhenQueryAPI.kt"), generatedFileNames);
+
+        for (File file : files) {
+            if (filters.contains(file.getName())) {
+                assertSameTrimmedContent(
+                        new File(String.format("src/test/resources/expected-classes/kt/restricted-words/%s.txt", file.getName())),
+                        file);
+            }
+        }
+    }
+
+}

--- a/src/test/resources/expected-classes/kt/restricted-words/QueryFunParametrizedInput.kt.txt
+++ b/src/test/resources/expected-classes/kt/restricted-words/QueryFunParametrizedInput.kt.txt
@@ -1,6 +1,7 @@
 package com.kobylynskyi.graphql.codegen.prot
 
 import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLParametrizedInput
+import java.util.StringJoiner
 /**
  * Parametrized input for field fun in type Query
  */
@@ -10,4 +11,13 @@ import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLParametrizedInput
 )
 data class QueryFunParametrizedInput(
     val final: Int?
-) : GraphQLParametrizedInput
+) : GraphQLParametrizedInput {
+
+    override fun toString(): String {
+        val joiner = StringJoiner(", ", "( ", " )")
+        if (final != null) {
+            joiner.add("final: " + GraphQLRequestSerializer.getEntry(final))
+        }
+        return joiner.toString()
+    }
+}

--- a/src/test/resources/expected-classes/kt/restricted-words/Super.kt.txt
+++ b/src/test/resources/expected-classes/kt/restricted-words/Super.kt.txt
@@ -10,9 +10,9 @@ import java.util.StringJoiner
 data class Super(
     @Deprecated("this is deprecated in GraphQL")
     val `is`: String?,
-    val `in`: Char,
-    val Int: Super,
-    val date: String
+    val `in`: Char?,
+    val Int: Super?,
+    val date: String?
 ) {
 
     companion object {
@@ -25,18 +25,24 @@ data class Super(
         if (`is` != null) {
             joiner.add("is: " + GraphQLRequestSerializer.getEntry(`is`))
         }
-        joiner.add("in: " + GraphQLRequestSerializer.getEntry(`in`))
-        joiner.add("Int: " + GraphQLRequestSerializer.getEntry(Int))
-        joiner.add("date: " + GraphQLRequestSerializer.getEntry(date))
+        if (`in` != null) {
+            joiner.add("in: " + GraphQLRequestSerializer.getEntry(`in`))
+        }
+        if (Int != null) {
+            joiner.add("Int: " + GraphQLRequestSerializer.getEntry(Int))
+        }
+        if (date != null) {
+            joiner.add("date: " + GraphQLRequestSerializer.getEntry(date))
+        }
         return joiner.toString()
     }
 
     class Builder {
 
         private var `is`: String? = null
-        private var `in`: Char = 0.toChar()
-        private lateinit var Int: Super
-        private lateinit var date: String
+        private var `in`: Char? = null
+        private var Int: Super? = null
+        private var date: String? = null
 
         @Deprecated("this is deprecated in GraphQL")
         fun setIs(`is`: String?): Builder {
@@ -44,17 +50,17 @@ data class Super(
             return this
         }
 
-        fun setIn(`in`: Char): Builder {
+        fun setIn(`in`: Char?): Builder {
             this.`in` = `in`
             return this
         }
 
-        fun setInt(Int: Super): Builder {
+        fun setInt(Int: Super?): Builder {
             this.Int = Int
             return this
         }
 
-        fun setDate(date: String): Builder {
+        fun setDate(date: String?): Builder {
             this.date = date
             return this
         }

--- a/src/test/resources/expected-classes/kt/restricted-words/WhenQueryAPI.kt.txt
+++ b/src/test/resources/expected-classes/kt/restricted-words/WhenQueryAPI.kt.txt
@@ -8,6 +8,6 @@ package com.kobylynskyi.graphql.codegen.prot
 interface WhenQueryAPI {
 
     @Throws(Exception::class)
-    fun `when`(final: List<Char>): String?
+    fun `when`(final: List<Char?>?): String?
 
 }

--- a/src/test/resources/expected-classes/scala/tostring/QueryPrivateParametrizedInput.scala.txt
+++ b/src/test/resources/expected-classes/scala/tostring/QueryPrivateParametrizedInput.scala.txt
@@ -1,6 +1,7 @@
 package com.kobylynskyi.graphql.codegen.prot
 
 import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLParametrizedInput
+import scala.collection.JavaConverters._
 import TestEnum._
 
 /**
@@ -11,7 +12,23 @@ import TestEnum._
     date = "2020-12-31T23:59:59-0500"
 )
 case class QueryPrivateParametrizedInput(
-    int: Option[Int],
+    int: Int,
+    intOpt: Option[Int],
+    seq1: Seq[Option[Int]],
+    seq2: Seq[Int],
     `new`: String,
     enum: TestEnum = TestEnum.long
-) extends GraphQLParametrizedInput
+) extends GraphQLParametrizedInput {
+
+    override def toString(): String = {
+        Seq(
+            "int: " + GraphQLRequestSerializer.getEntry(int),
+            if (intOpt.isDefined) "intOpt: " + GraphQLRequestSerializer.getEntry(intOpt.get) else "",
+            if (seq1 != null) "seq1: " + GraphQLRequestSerializer.getEntry(seq1.asJava) else "",
+            if (seq2 != null) "seq2: " + GraphQLRequestSerializer.getEntry(seq2.asJava) else "",
+            if (`new` != null) "new: " + GraphQLRequestSerializer.getEntry(`new`) else "",
+            if (enum != null) "enum: " + GraphQLRequestSerializer.getEntry(enum) else ""
+        ).filter(_ != "").mkString("(", ",", ")")
+    }
+
+}

--- a/src/test/resources/schemas/scala/restricted-words.graphqls
+++ b/src/test/resources/schemas/scala/restricted-words.graphqls
@@ -4,7 +4,7 @@ schema {
 
 type Query {
     native: String
-    private(int: Int, new: String, enum: TestEnum = long): Synchronized
+    private(int: Int!, intOpt:Int, seq1:[Int], seq2:[Int!], new: String, enum: TestEnum = long): Synchronized
     case(final: [char]): ID
     int(final: Int): char
     super: String


### PR DESCRIPTION
Previously, we(and @joffrey-bion ) mistakenly thought that the toString of ```ParametrizedInput``` had no business content and was only used for visualization. Today, I find that it actually serves as parameter  selection in graphql query.
Such as,
```java
public class EventPropertyChildParametrizedInput implements GraphQLParametrizedInput {

    private Integer first;
    private Integer last;
......
}
```
I consider it must be serialized to the following format. If my guess is right, it's caused by kotlin pr. please take a look.
```java
 String expectedQueryStr = "query { " +
          "eventsByCategoryAndStatus(categoryId: \"categoryIdValue1\", status: OPEN){ " +
          "id " +
          "active " +
          "properties { " +
          "floatVal myChild : child (first: 10, last: -10) { intVal myParent : parent (withStatus: OPEN) { id } } booleanVal } " +
          "status " +
          "} " +
          "}";
```