### PR TITLE
Exception fix for non-query compound requests

### DIFF
--- a/src/main/java/com/kobylynskyi/graphql/codegen/model/graphql/GraphQLRequestSerializer.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/model/graphql/GraphQLRequestSerializer.java
@@ -30,7 +30,7 @@ public class GraphQLRequestSerializer {
         if (graphQLRequests.getRequests().isEmpty()) {
             throw new IllegalArgumentException("At least one GraphQL request should be supplied");
         }
-        GraphQLOperation operation = GraphQLOperation.QUERY;
+        GraphQLOperation operation = graphQLRequests.getRequests().get(0).getRequest().getOperationType();
         StringBuilder queryBuilder = new StringBuilder();
         for (GraphQLRequest request : graphQLRequests.getRequests()) {
             if (request == null || request.getRequest() == null) {
@@ -40,7 +40,6 @@ public class GraphQLRequestSerializer {
                 throw new IllegalArgumentException("Only operations of the same type (query/mutation/subscription) can be executed at once");
             }
             queryBuilder.append(buildQuery(request)).append(" ");
-            operation = request.getRequest().getOperationType();
         }
         return jsonQuery(operationWrapper(queryBuilder.toString(), operation));
     }


### PR DESCRIPTION
Hi,

I encountered a bug while using the GraphQLRequests#toHttpJsonBody method, causing it to be unable to compile requests of non-query types.

I swapped the code to use the first request's operation type instead of using the default QUERY type, as the value would only be updated in the loop, after the check with exception had already happened.

The operation of getting the first entry is safe to use as the list is checked before to not be empty.

Hope to hear from you, and have an update for our usage 👍 