### PR TITLE
Revert "Bump jackson-databind from 2.12.1 to 2.12.2"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 dependencies {
     implementation "org.freemarker:freemarker:2.3.31"
     implementation "com.graphql-java:graphql-java:15.0"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.2"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.1"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.7.1"


### PR DESCRIPTION
Reverts kobylynskyi/graphql-java-codegen#565

There are issues with the 2.12.2 jackson release: https://github.com/FasterXML/jackson-jaxrs-providers/issues/138.  It doesn't affect this project specifically, but it can affect others using the project (myself included).  Easiest fix is to just revert to a stable build and skip 2.12.2 once 2.12.3 is released.