### PR TITLE
Don't fail with enums in directive parameters.

### DIFF
--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/ValueMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/ValueMapper.java
@@ -129,6 +129,9 @@ public class ValueMapper {
         if (graphQLType instanceof NonNullType) {
             return mapEnum(mappingContext, value, ((NonNullType) graphQLType).getType());
         }
+        if (graphQLType == null) {
+            return value.getName();
+        }
         throw new IllegalArgumentException("Unexpected Enum value for list type");
     }
 

--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/ValueMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/ValueMapper.java
@@ -121,6 +121,9 @@ public class ValueMapper {
     }
 
     private String mapEnum(MappingContext mappingContext, EnumValue value, Type<?> graphQLType) {
+        if (graphQLType == null) {
+            return value.getName();
+        }
         if (graphQLType instanceof TypeName) {
             String typeName = ((TypeName) graphQLType).getName();
             typeName = DataModelMapper.getModelClassNameWithPrefixAndSuffix(mappingContext, typeName);
@@ -128,9 +131,6 @@ public class ValueMapper {
         }
         if (graphQLType instanceof NonNullType) {
             return mapEnum(mappingContext, value, ((NonNullType) graphQLType).getType());
-        }
-        if (graphQLType == null) {
-            return value.getName();
         }
         throw new IllegalArgumentException("Unexpected Enum value for list type");
     }

--- a/src/main/resources/templates/scala-lang/scalaClassGraphqlType.ftl
+++ b/src/main/resources/templates/scala-lang/scalaClassGraphqlType.ftl
@@ -15,22 +15,36 @@ import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLRequestSerializer
 import java.util.Objects
 </#if>
 import scala.collection.JavaConverters._
+<#assign duplicateEnumImports = [] />
+<#assign enumImports = [] />
 <#if fields?has_content>
     <#if enumImportItSelfInScala?has_content>
         <#list fields as field>
             <#list enumImportItSelfInScala as enum>
                 <#if MapperUtil.isScalaCollection(field.type)>
                     <#if enum == MapperUtil.getGenericParameter(field.type)>
-import ${enum}._
+                        <#assign duplicateEnumImports = duplicateEnumImports + [enum] />
                     </#if>
                 <#else >
                     <#if enum == field.type>
-import ${enum}._
+                        <#assign duplicateEnumImports = duplicateEnumImports + [enum] />
                     </#if>
                 </#if>
             </#list>
         </#list>
     </#if>
+</#if>
+<#if duplicateEnumImports?has_content>
+    <#list duplicateEnumImports as duplicateEnumImport>
+        <#if !enumImports?seq_contains(duplicateEnumImport)>
+            <#assign enumImports = enumImports + [duplicateEnumImport]>
+        </#if>
+    </#list>
+</#if>
+<#if enumImports?has_content>
+    <#list enumImports as enumImport>
+import ${enumImport}._
+    </#list>
 </#if>
 <#assign duplicateParentInterfaces = [] />
 <#assign parentInterfaces = [] />

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenAnnotationsTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenAnnotationsTest.java
@@ -210,6 +210,8 @@ class GraphQLCodegenAnnotationsTest {
                         "n={{n?toString}})"));
         directiveAnnotationsMapping.put("valid", singletonList("@javax.validation.Valid"));
         directiveAnnotationsMapping.put("customResolver", singletonList("@com.example.CustomAnnotation"));
+        directiveAnnotationsMapping.put("relationship",
+                singletonList("@com.example.Relationship(type = {{type}}, direction = {{direction}})"));
         mappingConfig.setDirectiveAnnotationsMapping(directiveAnnotationsMapping);
 
         new JavaGraphQLCodegen(singletonList("src/test/resources/schemas/test.graphqls"),
@@ -225,6 +227,9 @@ class GraphQLCodegenAnnotationsTest {
         assertSameTrimmedContent(
             new File("src/test/resources/expected-classes/annotation/EventProperty.java.txt"),
             getFileByName(files, "EventProperty.java"));
+        assertSameTrimmedContent(
+            new File("src/test/resources/expected-classes/annotation/User.java.txt"),
+            getFileByName(files, "User.java"));
     }
 
 }

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenApisTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenApisTest.java
@@ -138,7 +138,7 @@ class GraphQLCodegenApisTest {
         File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
         assertEquals(Arrays.asList(
                 "Event.java", "EventProperty.java", "EventPropertyResolver.java", "EventStatus.java",
-                "MutationResolver.java", "QueryResolver.java", "SubscriptionResolver.java"),
+                "MutationResolver.java", "QueryResolver.java", "SubscriptionResolver.java", "User.java"),
                 Arrays.stream(files).map(File::getName).sorted().collect(toList()));
     }
 
@@ -155,7 +155,8 @@ class GraphQLCodegenApisTest {
         assertEquals(Arrays.asList(
                 "CreateEventMutationResolver.java", "Event.java", "EventByIdQueryResolver.java", "EventProperty.java",
                 "EventPropertyResolver.java", "EventStatus.java", "EventsByCategoryAndStatusQueryResolver.java",
-                "EventsByIdsQueryResolver.java", "EventsCreatedSubscriptionResolver.java", "VersionQueryResolver.java"),
+                "EventsByIdsQueryResolver.java", "EventsCreatedSubscriptionResolver.java", "User.java",
+                "VersionQueryResolver.java"),
                 Arrays.stream(files).map(File::getName).sorted().collect(toList()));
     }
 

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenModelsForRootTypesTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenModelsForRootTypesTest.java
@@ -72,7 +72,7 @@ class GraphQLCodegenModelsForRootTypesTest {
         File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
         List<String> generatedFileNames = Arrays.stream(files).map(File::getName).sorted().collect(toList());
         assertEquals(Arrays.asList("Event.java", "EventProperty.java", "EventStatus.java",
-                "Mutation.java", "Query.java", "Subscription.java"),
+                "Mutation.java", "Query.java", "Subscription.java", "User.java"),
                 generatedFileNames);
     }
 
@@ -89,7 +89,8 @@ class GraphQLCodegenModelsForRootTypesTest {
                 "EventsByCategoryAndStatusQueryResolver.java", "EventsByIdsQueryResolver.java",
                 "EventsCreatedSubscriptionResolver.java", "Mutation.java", "MutationResolver.java",
                 "MutationTypeResolver.java", "Query.java", "QueryResolver.java", "QueryTypeResolver.java",
-                "Subscription.java", "SubscriptionResolver.java", "VersionQueryResolver.java"), generatedFileNames);
+                "Subscription.java", "SubscriptionResolver.java", "User.java", "VersionQueryResolver.java"),
+                generatedFileNames);
     }
 
 }

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenTest.java
@@ -70,7 +70,7 @@ class GraphQLCodegenTest {
                 "CreateEventMutationResolver.java", "Event.java", "EventByIdQueryResolver.java", "EventProperty.java",
                 "EventStatus.java", "EventsByCategoryAndStatusQueryResolver.java", "EventsByIdsQueryResolver.java",
                 "EventsCreatedSubscriptionResolver.java", "MutationResolver.java", "QueryResolver.java",
-                "SubscriptionResolver.java",
+                "SubscriptionResolver.java", "User.java",
                 "VersionQueryResolver.java"), generatedFileNames);
 
         for (File file : files) {
@@ -170,7 +170,7 @@ class GraphQLCodegenTest {
 
         File[] modelFiles = Objects.requireNonNull(new File(outputJavaClassesDir, "model").listFiles());
         List<String> generatedModelFileNames = Arrays.stream(modelFiles).map(File::getName).sorted().collect(toList());
-        assertEquals(Arrays.asList("Event.java", "EventProperty.java", "EventStatus.java"), generatedModelFileNames);
+        assertEquals(Arrays.asList("Event.java", "EventProperty.java", "EventStatus.java", "User.java"), generatedModelFileNames);
 
         for (File modelFile : modelFiles) {
             assertThat(Utils.getFileContent(modelFile.getPath()),
@@ -296,7 +296,7 @@ class GraphQLCodegenTest {
 
         File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
         List<String> generatedFileNames = Arrays.stream(files).map(File::getName).sorted().collect(toList());
-        assertEquals(Arrays.asList("Event.java", "EventProperty.java", "EventStatus.java"), generatedFileNames);
+        assertEquals(Arrays.asList("Event.java", "EventProperty.java", "EventStatus.java", "User.java"), generatedFileNames);
     }
 
     @Test

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenTest.java
@@ -170,7 +170,8 @@ class GraphQLCodegenTest {
 
         File[] modelFiles = Objects.requireNonNull(new File(outputJavaClassesDir, "model").listFiles());
         List<String> generatedModelFileNames = Arrays.stream(modelFiles).map(File::getName).sorted().collect(toList());
-        assertEquals(Arrays.asList("Event.java", "EventProperty.java", "EventStatus.java", "User.java"), generatedModelFileNames);
+        assertEquals(Arrays.asList("Event.java", "EventProperty.java", "EventStatus.java", "User.java"),
+                generatedModelFileNames);
 
         for (File modelFile : modelFiles) {
             assertThat(Utils.getFileContent(modelFile.getPath()),
@@ -296,7 +297,8 @@ class GraphQLCodegenTest {
 
         File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
         List<String> generatedFileNames = Arrays.stream(files).map(File::getName).sorted().collect(toList());
-        assertEquals(Arrays.asList("Event.java", "EventProperty.java", "EventStatus.java", "User.java"), generatedFileNames);
+        assertEquals(Arrays.asList("Event.java", "EventProperty.java", "EventStatus.java", "User.java"),
+                generatedFileNames);
     }
 
     @Test

--- a/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenAnnotationsTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenAnnotationsTest.java
@@ -171,6 +171,8 @@ class GraphQLCodegenAnnotationsTest {
                         "@com.example.CustomAnnotation(roles={{roles?toArray}}, " +
                                 "boo={{boo?toArray}}, float={{float?toArrayOfStrings}}, int={{int}}, " +
                                 "n={{n?toString}})"));
+        directiveAnnotationsMapping.put("relationship",
+                singletonList("@com.example.Relationship(type = {{type}}, direction = {{direction}})"));
         mappingConfig.setDirectiveAnnotationsMapping(directiveAnnotationsMapping);
 
         new ScalaGraphQLCodegen(singletonList("src/test/resources/schemas/test.graphqls"),
@@ -183,6 +185,9 @@ class GraphQLCodegenAnnotationsTest {
         assertSameTrimmedContent(
                 new File("src/test/resources/expected-classes/scala/annotation/MutationResolver.scala.txt"),
                 getFileByName(files, "MutationResolver.scala"));
+        assertSameTrimmedContent(
+                new File("src/test/resources/expected-classes/scala/annotation/User.scala.txt"),
+                getFileByName(files, "User.scala"));
     }
 
 }

--- a/src/test/resources/expected-classes/User.java.txt
+++ b/src/test/resources/expected-classes/User.java.txt
@@ -1,0 +1,68 @@
+package com.kobylynskyi.graphql.test1;
+
+
+/**
+ * type with directive using enum value
+ */
+@javax.annotation.Generated(
+    value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+    date = "2020-12-31T23:59:59-0500"
+)
+public class User implements java.io.Serializable {
+
+    private String name;
+    private java.util.List<User> friends;
+
+    public User() {
+    }
+
+    public User(String name, java.util.List<User> friends) {
+        this.name = name;
+        this.friends = friends;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public java.util.List<User> getFriends() {
+        return friends;
+    }
+    public void setFriends(java.util.List<User> friends) {
+        this.friends = friends;
+    }
+
+
+
+    public static User.Builder builder() {
+        return new User.Builder();
+    }
+
+    public static class Builder {
+
+        private String name;
+        private java.util.List<User> friends;
+
+        public Builder() {
+        }
+
+        public Builder setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder setFriends(java.util.List<User> friends) {
+            this.friends = friends;
+            return this;
+        }
+
+
+        public User build() {
+            return new User(name, friends);
+        }
+
+    }
+}

--- a/src/test/resources/expected-classes/annotation/User.java.txt
+++ b/src/test/resources/expected-classes/annotation/User.java.txt
@@ -1,0 +1,69 @@
+package com.kobylynskyi.graphql.test1;
+
+
+/**
+ * type with directive using enum value
+ */
+@javax.annotation.Generated(
+    value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+    date = "2020-12-31T23:59:59-0500"
+)
+public class User implements java.io.Serializable {
+
+    private String name;
+    @com.example.Relationship(type = "FRIEND_WITH", direction = OUT)
+    private java.util.List<User> friends;
+
+    public User() {
+    }
+
+    public User(String name, java.util.List<User> friends) {
+        this.name = name;
+        this.friends = friends;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public java.util.List<User> getFriends() {
+        return friends;
+    }
+    public void setFriends(java.util.List<User> friends) {
+        this.friends = friends;
+    }
+
+
+
+    public static User.Builder builder() {
+        return new User.Builder();
+    }
+
+    public static class Builder {
+
+        private String name;
+        private java.util.List<User> friends;
+
+        public Builder() {
+        }
+
+        public Builder setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder setFriends(java.util.List<User> friends) {
+            this.friends = friends;
+            return this;
+        }
+
+
+        public User build() {
+            return new User(name, friends);
+        }
+
+    }
+}

--- a/src/test/resources/expected-classes/scala/annotation/User.scala.txt
+++ b/src/test/resources/expected-classes/scala/annotation/User.scala.txt
@@ -1,0 +1,18 @@
+package com.kobylynskyi.graphql.test1
+
+import scala.collection.JavaConverters._
+
+/**
+ * type with directive using enum value
+ */
+@javax.annotation.Generated(
+    value = Array("com.kobylynskyi.graphql.codegen.GraphQLCodegen"),
+    date = "2020-12-31T23:59:59-0500"
+)
+case class User(
+    name: String,
+    @com.example.Relationship(type = "FRIEND_WITH", direction = OUT)
+    friends: scala.Seq[User]
+) {
+
+}

--- a/src/test/resources/schemas/test.graphqls
+++ b/src/test/resources/schemas/test.graphqls
@@ -95,6 +95,12 @@ enum EventStatus {
     LOGGED
 }
 
+# type with directive using enum value
+type User {
+    name: String,
+    friends: [User] @relationship(type: "FRIEND_WITH", direction: OUT)
+}
+
 directive @auth (
     roles: [String] = ["viewer"],
     float: [Float] = [],


### PR DESCRIPTION
---

### Description

Support mapping of enum values in directive parameters.
This does currently fail and I _think_ that this little bit extra for the `null`-handling can improve the situation.
I am pretty new to the whole GraphQL world and do not know if this makes sense at all.
Since I haven't found a similar test scenario for Kotlin, I skipped this part for this PR and just focused on Scala and Java.

Related to #673

---

Changes were made to:
- [x] Codegen library - Java
- [ ] Codegen library - Kotlin
- [x] Codegen library - Scala