### PR TITLE
Add @JvmStatic annotation to Kotlin builders

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,19 +16,20 @@ Before sending your pull requests, make sure you followed this list:
 Please follow the steps below in order to make the changes:
 
 1. Clone the repository
-2. Checkout **develop** branch.
-3. Open repository in your favourite IDE.
-4. Enable and configure CheckStyle plugin in your IDE (for IntelliJ it is CheckStyle-IDEA).
+2. Set the local java version to 1.8
+3. Checkout **develop** branch.
+4. Open repository in your favourite IDE.
+5. Enable and configure CheckStyle plugin in your IDE (for IntelliJ it is CheckStyle-IDEA).
    Import [graphql-codegen-check-style.xml](config/checkstyle/graphql-codegen-check-style.xml) as a .
-5. Make code changes to the core library of `graphql-java-codegen`.
-6. If changes are required in the plugin code, then **build** and **install** `graphql-java-codegen` first.
+6. Make code changes to the core library of `graphql-java-codegen`.
+7. If changes are required in the plugin code, then **build** and **install** `graphql-java-codegen` first.
 
    ```shell script
    # This will install the library (including your recent changes) in your local maven repository.
    ./gradlew clean build publishToMavenLocal
    ```
 
-7. Build the plugin project with updated `graphql-java-codegen` library.
+8. Build the plugin project with updated `graphql-java-codegen` library.
 
    ```shell script
    # Build Gradle plugin
@@ -39,8 +40,8 @@ Please follow the steps below in order to make the changes:
    mvn clean verify 
    ```
 
-8. Make changes to the plugin code
-9. Install the plugin (copy to your local maven repository).
+9. Make changes to the plugin code
+10. Install the plugin (copy to your local maven repository).
 
    ```shell script
    # Install Gradle plugin
@@ -51,4 +52,4 @@ Please follow the steps below in order to make the changes:
    mvn clean install 
    ```
 
-10. Make sure that `example` projects are compiling and running.
+11. Make sure that `example` projects are compiling and running.

--- a/src/main/resources/templates/kotlin-lang/kotlinClassGraphqlRequest.ftl
+++ b/src/main/resources/templates/kotlin-lang/kotlinClassGraphqlRequest.ftl
@@ -32,7 +32,7 @@ open class ${className}(private val alias: String?) : GraphQLOperationRequest {
         val OPERATION_TYPE: GraphQLOperation = GraphQLOperation.${operationType}
 <#if builder>
 
-        fun builder(): Builder = Builder()
+        @JvmStatic fun builder(): Builder = Builder()
 </#if>
     }
 

--- a/src/main/resources/templates/kotlin-lang/kotlinClassGraphqlType.ftl
+++ b/src/main/resources/templates/kotlin-lang/kotlinClassGraphqlType.ftl
@@ -75,7 +75,7 @@ open class ${className}()<#if implements?has_content> : <#list implements as int
 
 <#if builder>
     companion object {
-        fun builder(): Builder = Builder()
+        @JvmStatic fun builder(): Builder = Builder()
     }
 
 </#if>

--- a/src/test/resources/expected-classes/kt/Commit_no_final_class.kt.txt
+++ b/src/test/resources/expected-classes/kt/Commit_no_final_class.kt.txt
@@ -60,7 +60,7 @@ open class Commit(
 ) : Closer, IssueTimelineItem, PullRequestTimelineItem, Subscribable, Node, GitObject, UniformResourceLocatable {
 
     companion object {
-        fun builder(): Builder = Builder()
+        @JvmStatic fun builder(): Builder = Builder()
     }
 
     // In the future, it maybe change.

--- a/src/test/resources/expected-classes/kt/optional/TypeWithMandatoryField.kt.txt
+++ b/src/test/resources/expected-classes/kt/optional/TypeWithMandatoryField.kt.txt
@@ -10,7 +10,7 @@ data class TypeWithMandatoryField(
 ) : InterfaceWithOptionalField {
 
     companion object {
-        fun builder(): Builder = Builder()
+        @JvmStatic fun builder(): Builder = Builder()
     }
 
     // In the future, it maybe change.

--- a/src/test/resources/expected-classes/kt/restricted-words/FunQueryRequest.kt.txt
+++ b/src/test/resources/expected-classes/kt/restricted-words/FunQueryRequest.kt.txt
@@ -14,7 +14,7 @@ open class FunQueryRequest(private val alias: String?) : GraphQLOperationRequest
         const val OPERATION_NAME: String = "fun"
         val OPERATION_TYPE: GraphQLOperation = GraphQLOperation.QUERY
 
-        fun builder(): Builder = Builder()
+        @JvmStatic fun builder(): Builder = Builder()
     }
 
     private val input: MutableMap<String, Any?> = LinkedHashMap()

--- a/src/test/resources/expected-classes/kt/restricted-words/Super.kt.txt
+++ b/src/test/resources/expected-classes/kt/restricted-words/Super.kt.txt
@@ -16,7 +16,7 @@ data class Super(
 ) {
 
     companion object {
-        fun builder(): Builder = Builder()
+        @JvmStatic fun builder(): Builder = Builder()
     }
 
     // In the future, it maybe change.


### PR DESCRIPTION
---

### Description

Related to #767 

Adds @JvmStatic to the Kotlin builders so that they can be "backwards-compatible" with Java generated code.

CONTRIBUTING.md changed to mention Java 8 due to issue introduced in #741

---

Changes were made to:
- [ ] Codegen library - Java
- [x] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
