### PR TITLE
Add serialVersionUID to generated classes that implement Serializable

### DIFF
--- a/plugins/maven/graphql-java-codegen-maven-plugin/pom.xml
+++ b/plugins/maven/graphql-java-codegen-maven-plugin/pom.xml
@@ -36,7 +36,7 @@
         <developerConnection>scm:git:git@github.com:kobylynskyi/graphql-java-codegen.git
         </developerConnection>
         <url>https://github.com/kobylynskyi/graphql-java-codegen/tree/master/plugins/maven</url>
-        <tag>v5.3.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/src/main/resources/templates/java-lang/type.ftl
+++ b/src/main/resources/templates/java-lang/type.ftl
@@ -36,6 +36,9 @@ import java.util.StringJoiner;
 </#list>
 public class ${className} implements java.io.Serializable<#if implements?has_content><#list implements as interface>, ${interface}<#if interface_has_next></#if></#list></#if> {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
 <#if fields?has_content>
     <#list fields as field>
         <#if field.deprecated?has_content>

--- a/src/main/resources/templates/java-lang/type.ftl
+++ b/src/main/resources/templates/java-lang/type.ftl
@@ -36,7 +36,6 @@ import java.util.StringJoiner;
 </#list>
 public class ${className} implements java.io.Serializable<#if implements?has_content><#list implements as interface>, ${interface}<#if interface_has_next></#if></#list></#if> {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
 <#if fields?has_content>

--- a/src/test/resources/expected-classes/CommentDeletedEvent.java.txt
+++ b/src/test/resources/expected-classes/CommentDeletedEvent.java.txt
@@ -7,7 +7,6 @@ package com.github.graphql;
 )
 public class CommentDeletedEvent implements java.io.Serializable, IssueTimelineItems, PullRequestTimelineItems, Node {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/CommentDeletedEvent.java.txt
+++ b/src/test/resources/expected-classes/CommentDeletedEvent.java.txt
@@ -7,6 +7,9 @@ package com.github.graphql;
 )
 public class CommentDeletedEvent implements java.io.Serializable, IssueTimelineItems, PullRequestTimelineItems, Node {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String id;
 

--- a/src/test/resources/expected-classes/Commit.java.txt
+++ b/src/test/resources/expected-classes/Commit.java.txt
@@ -7,7 +7,6 @@ package com.github.graphql;
 )
 public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, PullRequestTimelineItem, Subscribable, Node, GitObject, UniformResourceLocatable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/Commit.java.txt
+++ b/src/test/resources/expected-classes/Commit.java.txt
@@ -7,6 +7,9 @@ package com.github.graphql;
 )
 public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, PullRequestTimelineItem, Subscribable, Node, GitObject, UniformResourceLocatable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String abbreviatedOid;
     private int additions;

--- a/src/test/resources/expected-classes/Commit_noParametrizedFields.java.txt
+++ b/src/test/resources/expected-classes/Commit_noParametrizedFields.java.txt
@@ -7,7 +7,6 @@ package com.github.graphql;
 )
 public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, PullRequestTimelineItem, Subscribable, Node, GitObject, UniformResourceLocatable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/Commit_noParametrizedFields.java.txt
+++ b/src/test/resources/expected-classes/Commit_noParametrizedFields.java.txt
@@ -7,6 +7,9 @@ package com.github.graphql;
 )
 public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, PullRequestTimelineItem, Subscribable, Node, GitObject, UniformResourceLocatable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String abbreviatedOid;
     private int additions;

--- a/src/test/resources/expected-classes/Commit_noValidationAnnotation.java.txt
+++ b/src/test/resources/expected-classes/Commit_noValidationAnnotation.java.txt
@@ -7,7 +7,6 @@ package com.github.graphql;
 )
 public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, PullRequestTimelineItem, Subscribable, Node, GitObject, UniformResourceLocatable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String abbreviatedOid;

--- a/src/test/resources/expected-classes/Commit_noValidationAnnotation.java.txt
+++ b/src/test/resources/expected-classes/Commit_noValidationAnnotation.java.txt
@@ -7,6 +7,9 @@ package com.github.graphql;
 )
 public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, PullRequestTimelineItem, Subscribable, Node, GitObject, UniformResourceLocatable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String abbreviatedOid;
     private int additions;
     private PullRequestConnection associatedPullRequests;

--- a/src/test/resources/expected-classes/Commit_withoutPrimitives.java.txt
+++ b/src/test/resources/expected-classes/Commit_withoutPrimitives.java.txt
@@ -7,6 +7,9 @@ package com.github.graphql;
 )
 public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, PullRequestTimelineItem, Subscribable, Node, GitObject, UniformResourceLocatable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String abbreviatedOid;
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/Commit_withoutPrimitives.java.txt
+++ b/src/test/resources/expected-classes/Commit_withoutPrimitives.java.txt
@@ -7,7 +7,6 @@ package com.github.graphql;
 )
 public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, PullRequestTimelineItem, Subscribable, Node, GitObject, UniformResourceLocatable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/Event.java.txt
+++ b/src/test/resources/expected-classes/Event.java.txt
@@ -10,7 +10,6 @@ package com.kobylynskyi.graphql.test1;
 )
 public class Event implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String id;

--- a/src/test/resources/expected-classes/Event.java.txt
+++ b/src/test/resources/expected-classes/Event.java.txt
@@ -10,6 +10,9 @@ package com.kobylynskyi.graphql.test1;
 )
 public class Event implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String id;
     private String categoryId;
     private java.util.List<EventProperty> properties;

--- a/src/test/resources/expected-classes/EventProperty.java.txt
+++ b/src/test/resources/expected-classes/EventProperty.java.txt
@@ -10,6 +10,9 @@ package com.kobylynskyi.graphql.test1;
 )
 public class EventProperty implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private Double floatVal;
     private Boolean booleanVal;
     private int intVal;

--- a/src/test/resources/expected-classes/EventProperty.java.txt
+++ b/src/test/resources/expected-classes/EventProperty.java.txt
@@ -10,7 +10,6 @@ package com.kobylynskyi.graphql.test1;
 )
 public class EventProperty implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private Double floatVal;

--- a/src/test/resources/expected-classes/EventPropertyTO_toString.java.txt
+++ b/src/test/resources/expected-classes/EventPropertyTO_toString.java.txt
@@ -11,7 +11,6 @@ import java.util.StringJoiner;
 )
 public class EventPropertyTO implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private Double floatVal;

--- a/src/test/resources/expected-classes/EventPropertyTO_toString.java.txt
+++ b/src/test/resources/expected-classes/EventPropertyTO_toString.java.txt
@@ -11,6 +11,9 @@ import java.util.StringJoiner;
 )
 public class EventPropertyTO implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private Double floatVal;
     private Boolean booleanVal;
     private int intVal;

--- a/src/test/resources/expected-classes/EventPropertyTO_withEqualsAndHashCode.java.txt
+++ b/src/test/resources/expected-classes/EventPropertyTO_withEqualsAndHashCode.java.txt
@@ -11,7 +11,6 @@ import java.util.Objects;
 )
 public class EventPropertyTO implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private Double floatVal;

--- a/src/test/resources/expected-classes/EventPropertyTO_withEqualsAndHashCode.java.txt
+++ b/src/test/resources/expected-classes/EventPropertyTO_withEqualsAndHashCode.java.txt
@@ -11,6 +11,9 @@ import java.util.Objects;
 )
 public class EventPropertyTO implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private Double floatVal;
     private Boolean booleanVal;
     private int intVal;

--- a/src/test/resources/expected-classes/EventPropertyTO_withoutGeneratedAnnotation.java.txt
+++ b/src/test/resources/expected-classes/EventPropertyTO_withoutGeneratedAnnotation.java.txt
@@ -6,7 +6,6 @@ package com.kobylynskyi.graphql.test1;
  */
 public class EventPropertyTO implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private Double floatVal;

--- a/src/test/resources/expected-classes/EventPropertyTO_withoutGeneratedAnnotation.java.txt
+++ b/src/test/resources/expected-classes/EventPropertyTO_withoutGeneratedAnnotation.java.txt
@@ -6,6 +6,9 @@ package com.kobylynskyi.graphql.test1;
  */
 public class EventPropertyTO implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private Double floatVal;
     private Boolean booleanVal;
     private int intVal;

--- a/src/test/resources/expected-classes/Event_noBuilder.java.txt
+++ b/src/test/resources/expected-classes/Event_noBuilder.java.txt
@@ -10,7 +10,6 @@ package com.kobylynskyi.graphql.test1;
 )
 public class Event implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String id;

--- a/src/test/resources/expected-classes/Event_noBuilder.java.txt
+++ b/src/test/resources/expected-classes/Event_noBuilder.java.txt
@@ -10,6 +10,9 @@ package com.kobylynskyi.graphql.test1;
 )
 public class Event implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String id;
     private String categoryId;
     private java.util.List<EventProperty> properties;

--- a/src/test/resources/expected-classes/GithubAcceptTopicSuggestionInputTO.java.txt
+++ b/src/test/resources/expected-classes/GithubAcceptTopicSuggestionInputTO.java.txt
@@ -7,7 +7,6 @@ package com.github.graphql;
 )
 public class GithubAcceptTopicSuggestionInputTO implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String clientMutationId;

--- a/src/test/resources/expected-classes/GithubAcceptTopicSuggestionInputTO.java.txt
+++ b/src/test/resources/expected-classes/GithubAcceptTopicSuggestionInputTO.java.txt
@@ -7,6 +7,9 @@ package com.github.graphql;
 )
 public class GithubAcceptTopicSuggestionInputTO implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String clientMutationId;
     @javax.validation.constraints.NotNull
     private String name;

--- a/src/test/resources/expected-classes/GithubAcceptTopicSuggestionPayloadTO.java.txt
+++ b/src/test/resources/expected-classes/GithubAcceptTopicSuggestionPayloadTO.java.txt
@@ -7,6 +7,9 @@ package com.github.graphql;
 )
 public class GithubAcceptTopicSuggestionPayloadTO implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String clientMutationId;
 
     public GithubAcceptTopicSuggestionPayloadTO() {

--- a/src/test/resources/expected-classes/GithubAcceptTopicSuggestionPayloadTO.java.txt
+++ b/src/test/resources/expected-classes/GithubAcceptTopicSuggestionPayloadTO.java.txt
@@ -7,7 +7,6 @@ package com.github.graphql;
 )
 public class GithubAcceptTopicSuggestionPayloadTO implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String clientMutationId;

--- a/src/test/resources/expected-classes/GithubCommitTO.java.txt
+++ b/src/test/resources/expected-classes/GithubCommitTO.java.txt
@@ -7,7 +7,6 @@ package com.github.graphql;
 )
 public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, GithubIssueTimelineItemTO, GithubPullRequestTimelineItemTO, GithubGitObjectTO, GithubNodeTO, GithubSubscribableTO, GithubUniformResourceLocatableTO {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/GithubCommitTO.java.txt
+++ b/src/test/resources/expected-classes/GithubCommitTO.java.txt
@@ -7,6 +7,9 @@ package com.github.graphql;
 )
 public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, GithubIssueTimelineItemTO, GithubPullRequestTimelineItemTO, GithubGitObjectTO, GithubNodeTO, GithubSubscribableTO, GithubUniformResourceLocatableTO {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String abbreviatedOid;
     private int additions;

--- a/src/test/resources/expected-classes/Person.java.txt
+++ b/src/test/resources/expected-classes/Person.java.txt
@@ -7,7 +7,6 @@ package com.kobylynskyi.graphql.test1;
 )
 public class Person implements java.io.Serializable, NamedEntity {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String name;

--- a/src/test/resources/expected-classes/Person.java.txt
+++ b/src/test/resources/expected-classes/Person.java.txt
@@ -7,6 +7,9 @@ package com.kobylynskyi.graphql.test1;
 )
 public class Person implements java.io.Serializable, NamedEntity {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String name;
     private Integer age;
 

--- a/src/test/resources/expected-classes/Person1.java.txt
+++ b/src/test/resources/expected-classes/Person1.java.txt
@@ -7,6 +7,9 @@ package com.kobylynskyi.graphql.test1;
 )
 public class Person implements java.io.Serializable, NamedEntity {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @Deprecated
     private String name;
     private Integer age;

--- a/src/test/resources/expected-classes/Person1.java.txt
+++ b/src/test/resources/expected-classes/Person1.java.txt
@@ -7,7 +7,6 @@ package com.kobylynskyi.graphql.test1;
 )
 public class Person implements java.io.Serializable, NamedEntity {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @Deprecated

--- a/src/test/resources/expected-classes/UnionMember1.java.txt
+++ b/src/test/resources/expected-classes/UnionMember1.java.txt
@@ -7,7 +7,6 @@ package com.kobylynskyi.graphql.multifiles;
 )
 public class UnionMember1 implements java.io.Serializable, MyUnion {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private Integer someField;

--- a/src/test/resources/expected-classes/UnionMember1.java.txt
+++ b/src/test/resources/expected-classes/UnionMember1.java.txt
@@ -7,6 +7,9 @@ package com.kobylynskyi.graphql.multifiles;
 )
 public class UnionMember1 implements java.io.Serializable, MyUnion {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private Integer someField;
 
     public UnionMember1() {

--- a/src/test/resources/expected-classes/UnionMember2.java.txt
+++ b/src/test/resources/expected-classes/UnionMember2.java.txt
@@ -7,6 +7,9 @@ package com.kobylynskyi.graphql.multifiles;
 )
 public class UnionMember2 implements java.io.Serializable, MyUnion {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String someField;
 
     public UnionMember2() {

--- a/src/test/resources/expected-classes/UnionMember2.java.txt
+++ b/src/test/resources/expected-classes/UnionMember2.java.txt
@@ -7,7 +7,6 @@ package com.kobylynskyi.graphql.multifiles;
 )
 public class UnionMember2 implements java.io.Serializable, MyUnion {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String someField;

--- a/src/test/resources/expected-classes/User.java.txt
+++ b/src/test/resources/expected-classes/User.java.txt
@@ -10,7 +10,6 @@ package com.kobylynskyi.graphql.test1;
 )
 public class User implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String name;

--- a/src/test/resources/expected-classes/User.java.txt
+++ b/src/test/resources/expected-classes/User.java.txt
@@ -10,6 +10,9 @@ package com.kobylynskyi.graphql.test1;
 )
 public class User implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String name;
     private java.util.List<User> friends;
 

--- a/src/test/resources/expected-classes/annotation/EventProperty.java.txt
+++ b/src/test/resources/expected-classes/annotation/EventProperty.java.txt
@@ -11,7 +11,6 @@ package com.kobylynskyi.graphql.test1;
 @com.example.CustomAnnotation
 public class EventProperty implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private Double floatVal;

--- a/src/test/resources/expected-classes/annotation/EventProperty.java.txt
+++ b/src/test/resources/expected-classes/annotation/EventProperty.java.txt
@@ -11,6 +11,9 @@ package com.kobylynskyi.graphql.test1;
 @com.example.CustomAnnotation
 public class EventProperty implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private Double floatVal;
     private Boolean booleanVal;
     private int intVal;

--- a/src/test/resources/expected-classes/annotation/User.java.txt
+++ b/src/test/resources/expected-classes/annotation/User.java.txt
@@ -10,6 +10,9 @@ package com.kobylynskyi.graphql.test1;
 )
 public class User implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String name;
     @com.example.Relationship(type = "FRIEND_WITH", direction = OUT)
     private java.util.List<User> friends;

--- a/src/test/resources/expected-classes/annotation/User.java.txt
+++ b/src/test/resources/expected-classes/annotation/User.java.txt
@@ -10,7 +10,6 @@ package com.kobylynskyi.graphql.test1;
 )
 public class User implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String name;

--- a/src/test/resources/expected-classes/custom-type/ResponseContainingDate.java.txt
+++ b/src/test/resources/expected-classes/custom-type/ResponseContainingDate.java.txt
@@ -9,7 +9,6 @@ import java.util.StringJoiner;
 )
 public class ResponseContainingDate implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private java.time.ZonedDateTime a;

--- a/src/test/resources/expected-classes/custom-type/ResponseContainingDate.java.txt
+++ b/src/test/resources/expected-classes/custom-type/ResponseContainingDate.java.txt
@@ -9,6 +9,9 @@ import java.util.StringJoiner;
 )
 public class ResponseContainingDate implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private java.time.ZonedDateTime a;
 
     public ResponseContainingDate() {

--- a/src/test/resources/expected-classes/defaults/InputWithDefaults.java.txt
+++ b/src/test/resources/expected-classes/defaults/InputWithDefaults.java.txt
@@ -10,7 +10,6 @@ package com.kobylynskyi.graphql.testdefaults;
 )
 public class InputWithDefaults implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private Double floatVal = 1.23;

--- a/src/test/resources/expected-classes/defaults/InputWithDefaults.java.txt
+++ b/src/test/resources/expected-classes/defaults/InputWithDefaults.java.txt
@@ -10,6 +10,9 @@ package com.kobylynskyi.graphql.testdefaults;
 )
 public class InputWithDefaults implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private Double floatVal = 1.23;
     private Boolean booleanVal = false;
     private Integer intVal = 42;

--- a/src/test/resources/expected-classes/defaults/InputWithDefaultsDTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/InputWithDefaultsDTO.java.txt
@@ -10,7 +10,6 @@ package com.kobylynskyi.graphql.testdefaults;
 )
 public class InputWithDefaultsDTO implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private Double floatVal = 1.23;

--- a/src/test/resources/expected-classes/defaults/InputWithDefaultsDTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/InputWithDefaultsDTO.java.txt
@@ -10,6 +10,9 @@ package com.kobylynskyi.graphql.testdefaults;
 )
 public class InputWithDefaultsDTO implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private Double floatVal = 1.23;
     private Boolean booleanVal = false;
     private Integer intVal = 42;

--- a/src/test/resources/expected-classes/defaults/InputWithDefaultsTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/InputWithDefaultsTO.java.txt
@@ -10,7 +10,6 @@ package com.kobylynskyi.graphql.testdefaults;
 )
 public class InputWithDefaultsTO implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private Double floatVal = 1.23;

--- a/src/test/resources/expected-classes/defaults/InputWithDefaultsTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/InputWithDefaultsTO.java.txt
@@ -10,6 +10,9 @@ package com.kobylynskyi.graphql.testdefaults;
 )
 public class InputWithDefaultsTO implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private Double floatVal = 1.23;
     private Boolean booleanVal = false;
     private Integer intVal = 42;

--- a/src/test/resources/expected-classes/defaults/SomeObject.java.txt
+++ b/src/test/resources/expected-classes/defaults/SomeObject.java.txt
@@ -7,7 +7,6 @@ package com.kobylynskyi.graphql.testdefaults;
 )
 public class SomeObject implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/defaults/SomeObject.java.txt
+++ b/src/test/resources/expected-classes/defaults/SomeObject.java.txt
@@ -7,6 +7,9 @@ package com.kobylynskyi.graphql.testdefaults;
 )
 public class SomeObject implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String name;
 

--- a/src/test/resources/expected-classes/defaults/SomeObjectDTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/SomeObjectDTO.java.txt
@@ -7,6 +7,9 @@ package com.kobylynskyi.graphql.testdefaults;
 )
 public class SomeObjectDTO implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String name;
 

--- a/src/test/resources/expected-classes/defaults/SomeObjectDTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/SomeObjectDTO.java.txt
@@ -7,7 +7,6 @@ package com.kobylynskyi.graphql.testdefaults;
 )
 public class SomeObjectDTO implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/defaults/SomeObjectTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/SomeObjectTO.java.txt
@@ -7,7 +7,6 @@ package com.kobylynskyi.graphql.testdefaults;
 )
 public class SomeObjectTO implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/defaults/SomeObjectTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/SomeObjectTO.java.txt
@@ -7,6 +7,9 @@ package com.kobylynskyi.graphql.testdefaults;
 )
 public class SomeObjectTO implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String name;
 

--- a/src/test/resources/expected-classes/deprecated/Event.java.txt
+++ b/src/test/resources/expected-classes/deprecated/Event.java.txt
@@ -7,6 +7,9 @@ package com.kobylynskyi.graphql.test1;
 )
 public class Event implements java.io.Serializable, PinnableItem, Node {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @Deprecated
     @javax.validation.constraints.NotNull
     private Status status;

--- a/src/test/resources/expected-classes/deprecated/Event.java.txt
+++ b/src/test/resources/expected-classes/deprecated/Event.java.txt
@@ -7,7 +7,6 @@ package com.kobylynskyi.graphql.test1;
 )
 public class Event implements java.io.Serializable, PinnableItem, Node {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @Deprecated

--- a/src/test/resources/expected-classes/deprecated/EventInput.java.txt
+++ b/src/test/resources/expected-classes/deprecated/EventInput.java.txt
@@ -7,7 +7,6 @@ package com.kobylynskyi.graphql.test1;
 )
 public class EventInput implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @Deprecated

--- a/src/test/resources/expected-classes/deprecated/EventInput.java.txt
+++ b/src/test/resources/expected-classes/deprecated/EventInput.java.txt
@@ -7,6 +7,9 @@ package com.kobylynskyi.graphql.test1;
 )
 public class EventInput implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @Deprecated
     @javax.validation.constraints.NotNull
     private Status status;

--- a/src/test/resources/expected-classes/empty/Event.java.txt
+++ b/src/test/resources/expected-classes/empty/Event.java.txt
@@ -4,6 +4,9 @@
 )
 public class Event implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
 
     public Event() {
     }

--- a/src/test/resources/expected-classes/empty/Event.java.txt
+++ b/src/test/resources/expected-classes/empty/Event.java.txt
@@ -4,7 +4,6 @@
 )
 public class Event implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
 

--- a/src/test/resources/expected-classes/empty/EventInput.java.txt
+++ b/src/test/resources/expected-classes/empty/EventInput.java.txt
@@ -4,7 +4,6 @@
 )
 public class EventInput implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
 

--- a/src/test/resources/expected-classes/empty/EventInput.java.txt
+++ b/src/test/resources/expected-classes/empty/EventInput.java.txt
@@ -4,6 +4,9 @@
 )
 public class EventInput implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
 
     public EventInput() {
     }

--- a/src/test/resources/expected-classes/extend-with-resolvers/Asset.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/Asset.java.txt
@@ -4,7 +4,6 @@
 )
 public class Asset implements java.io.Serializable, PinnableItem, Node {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/extend-with-resolvers/Asset.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/Asset.java.txt
@@ -4,6 +4,9 @@
 )
 public class Asset implements java.io.Serializable, PinnableItem, Node {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String name;
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/extend-with-resolvers/AssetInput.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/AssetInput.java.txt
@@ -4,6 +4,9 @@
 )
 public class AssetInput implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String name;
 

--- a/src/test/resources/expected-classes/extend-with-resolvers/AssetInput.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/AssetInput.java.txt
@@ -4,7 +4,6 @@
 )
 public class AssetInput implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/extend-with-resolvers/Event.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/Event.java.txt
@@ -4,7 +4,6 @@
 )
 public class Event implements java.io.Serializable, PinnableItem, Node {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/extend-with-resolvers/Event.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/Event.java.txt
@@ -4,6 +4,9 @@
 )
 public class Event implements java.io.Serializable, PinnableItem, Node {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private Status status;
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/extend-with-resolvers/EventInput.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/EventInput.java.txt
@@ -4,7 +4,6 @@
 )
 public class EventInput implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/extend-with-resolvers/EventInput.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/EventInput.java.txt
@@ -4,6 +4,9 @@
 )
 public class EventInput implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private Status status;
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/extend/Asset.java.txt
+++ b/src/test/resources/expected-classes/extend/Asset.java.txt
@@ -4,7 +4,6 @@
 )
 public class Asset implements java.io.Serializable, PinnableItem, Node {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/extend/Asset.java.txt
+++ b/src/test/resources/expected-classes/extend/Asset.java.txt
@@ -4,6 +4,9 @@
 )
 public class Asset implements java.io.Serializable, PinnableItem, Node {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String name;
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/extend/AssetInput.java.txt
+++ b/src/test/resources/expected-classes/extend/AssetInput.java.txt
@@ -4,6 +4,9 @@
 )
 public class AssetInput implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String name;
 

--- a/src/test/resources/expected-classes/extend/AssetInput.java.txt
+++ b/src/test/resources/expected-classes/extend/AssetInput.java.txt
@@ -4,7 +4,6 @@
 )
 public class AssetInput implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/extend/Event.java.txt
+++ b/src/test/resources/expected-classes/extend/Event.java.txt
@@ -4,7 +4,6 @@
 )
 public class Event implements java.io.Serializable, PinnableItem, Node {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/extend/Event.java.txt
+++ b/src/test/resources/expected-classes/extend/Event.java.txt
@@ -4,6 +4,9 @@
 )
 public class Event implements java.io.Serializable, PinnableItem, Node {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private Status status;
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/extend/EventInput.java.txt
+++ b/src/test/resources/expected-classes/extend/EventInput.java.txt
@@ -4,7 +4,6 @@
 )
 public class EventInput implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/extend/EventInput.java.txt
+++ b/src/test/resources/expected-classes/extend/EventInput.java.txt
@@ -4,6 +4,9 @@
 )
 public class EventInput implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private Status status;
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/from-introspection-result/Product.java.txt
+++ b/src/test/resources/expected-classes/from-introspection-result/Product.java.txt
@@ -9,7 +9,6 @@ import java.util.StringJoiner;
 )
 public class Product implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/from-introspection-result/Product.java.txt
+++ b/src/test/resources/expected-classes/from-introspection-result/Product.java.txt
@@ -9,6 +9,9 @@ import java.util.StringJoiner;
 )
 public class Product implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String id;
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/from-introspection-result/ProductInput.java.txt
+++ b/src/test/resources/expected-classes/from-introspection-result/ProductInput.java.txt
@@ -9,7 +9,6 @@ import java.util.StringJoiner;
 )
 public class ProductInput implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/from-introspection-result/ProductInput.java.txt
+++ b/src/test/resources/expected-classes/from-introspection-result/ProductInput.java.txt
@@ -9,6 +9,9 @@ import java.util.StringJoiner;
 )
 public class ProductInput implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String title;
     private String description;

--- a/src/test/resources/expected-classes/immutable/Event.java.txt
+++ b/src/test/resources/expected-classes/immutable/Event.java.txt
@@ -10,7 +10,6 @@ package com.kobylynskyi.graphql.immutable;
 )
 public class Event implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String id;

--- a/src/test/resources/expected-classes/immutable/Event.java.txt
+++ b/src/test/resources/expected-classes/immutable/Event.java.txt
@@ -10,6 +10,9 @@ package com.kobylynskyi.graphql.immutable;
 )
 public class Event implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String id;
     private String categoryId;
     private java.util.List<EventProperty> properties;

--- a/src/test/resources/expected-classes/interfaces/Bar1.java.txt
+++ b/src/test/resources/expected-classes/interfaces/Bar1.java.txt
@@ -7,6 +7,9 @@ package com.kobylynskyi.graphql.interfaces;
 )
 public class Bar1 implements java.io.Serializable, Bar {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String id;
 

--- a/src/test/resources/expected-classes/interfaces/Bar1.java.txt
+++ b/src/test/resources/expected-classes/interfaces/Bar1.java.txt
@@ -7,7 +7,6 @@ package com.kobylynskyi.graphql.interfaces;
 )
 public class Bar1 implements java.io.Serializable, Bar {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/interfaces/Foo1.java.txt
+++ b/src/test/resources/expected-classes/interfaces/Foo1.java.txt
@@ -7,6 +7,9 @@ package com.kobylynskyi.graphql.interfaces;
 )
 public class Foo1 implements java.io.Serializable, Foo {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String id;
     private java.util.List<Bar1> bars;

--- a/src/test/resources/expected-classes/interfaces/Foo1.java.txt
+++ b/src/test/resources/expected-classes/interfaces/Foo1.java.txt
@@ -7,7 +7,6 @@ package com.kobylynskyi.graphql.interfaces;
 )
 public class Foo1 implements java.io.Serializable, Foo {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/jackson-resolver-union/UnionMemberA.java.txt
+++ b/src/test/resources/expected-classes/jackson-resolver-union/UnionMemberA.java.txt
@@ -7,6 +7,9 @@ package com.kobylynskyi.graphql.unionresolver;
 )
 public class UnionMemberA implements java.io.Serializable, UnionToResolve {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private Integer someField;
 
     public UnionMemberA() {

--- a/src/test/resources/expected-classes/jackson-resolver-union/UnionMemberA.java.txt
+++ b/src/test/resources/expected-classes/jackson-resolver-union/UnionMemberA.java.txt
@@ -7,7 +7,6 @@ package com.kobylynskyi.graphql.unionresolver;
 )
 public class UnionMemberA implements java.io.Serializable, UnionToResolve {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private Integer someField;

--- a/src/test/resources/expected-classes/jackson-resolver-union/UnionMemberB.java.txt
+++ b/src/test/resources/expected-classes/jackson-resolver-union/UnionMemberB.java.txt
@@ -7,7 +7,6 @@ package com.kobylynskyi.graphql.unionresolver;
 )
 public class UnionMemberB implements java.io.Serializable, UnionToResolve {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String someField;

--- a/src/test/resources/expected-classes/jackson-resolver-union/UnionMemberB.java.txt
+++ b/src/test/resources/expected-classes/jackson-resolver-union/UnionMemberB.java.txt
@@ -7,6 +7,9 @@ package com.kobylynskyi.graphql.unionresolver;
 )
 public class UnionMemberB implements java.io.Serializable, UnionToResolve {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String someField;
 
     public UnionMemberB() {

--- a/src/test/resources/expected-classes/jackson-resolver-union/without-model-package/MyUnionMemberASuffix.java.txt
+++ b/src/test/resources/expected-classes/jackson-resolver-union/without-model-package/MyUnionMemberASuffix.java.txt
@@ -4,6 +4,9 @@
 )
 public class MyUnionMemberASuffix implements java.io.Serializable, MyUnionToResolveSuffix {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private Integer someField;
 
     public MyUnionMemberASuffix() {

--- a/src/test/resources/expected-classes/jackson-resolver-union/without-model-package/MyUnionMemberASuffix.java.txt
+++ b/src/test/resources/expected-classes/jackson-resolver-union/without-model-package/MyUnionMemberASuffix.java.txt
@@ -4,7 +4,6 @@
 )
 public class MyUnionMemberASuffix implements java.io.Serializable, MyUnionToResolveSuffix {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private Integer someField;

--- a/src/test/resources/expected-classes/jackson-resolver-union/without-model-package/MyUnionMemberBSuffix.java.txt
+++ b/src/test/resources/expected-classes/jackson-resolver-union/without-model-package/MyUnionMemberBSuffix.java.txt
@@ -4,7 +4,6 @@
 )
 public class MyUnionMemberBSuffix implements java.io.Serializable, MyUnionToResolveSuffix {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String someField;

--- a/src/test/resources/expected-classes/jackson-resolver-union/without-model-package/MyUnionMemberBSuffix.java.txt
+++ b/src/test/resources/expected-classes/jackson-resolver-union/without-model-package/MyUnionMemberBSuffix.java.txt
@@ -4,6 +4,9 @@
 )
 public class MyUnionMemberBSuffix implements java.io.Serializable, MyUnionToResolveSuffix {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String someField;
 
     public MyUnionMemberBSuffix() {

--- a/src/test/resources/expected-classes/optional/TypeWithMandatoryField.java.txt
+++ b/src/test/resources/expected-classes/optional/TypeWithMandatoryField.java.txt
@@ -7,7 +7,6 @@ import java.util.StringJoiner;
 )
 public class TypeWithMandatoryField implements java.io.Serializable, InterfaceWithOptionalField {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private int test;

--- a/src/test/resources/expected-classes/optional/TypeWithMandatoryField.java.txt
+++ b/src/test/resources/expected-classes/optional/TypeWithMandatoryField.java.txt
@@ -7,6 +7,9 @@ import java.util.StringJoiner;
 )
 public class TypeWithMandatoryField implements java.io.Serializable, InterfaceWithOptionalField {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private int test;
 
     public TypeWithMandatoryField() {

--- a/src/test/resources/expected-classes/relay/Organization.java.txt
+++ b/src/test/resources/expected-classes/relay/Organization.java.txt
@@ -5,7 +5,6 @@
 )
 public class Organization implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/relay/Organization.java.txt
+++ b/src/test/resources/expected-classes/relay/Organization.java.txt
@@ -5,6 +5,9 @@
 )
 public class Organization implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String id;
 

--- a/src/test/resources/expected-classes/relay/User.java.txt
+++ b/src/test/resources/expected-classes/relay/User.java.txt
@@ -5,7 +5,6 @@
 )
 public class User implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/relay/User.java.txt
+++ b/src/test/resources/expected-classes/relay/User.java.txt
@@ -5,6 +5,9 @@
 )
 public class User implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String id;
     private String name;

--- a/src/test/resources/expected-classes/request/AcceptTopicSuggestionInput.java.txt
+++ b/src/test/resources/expected-classes/request/AcceptTopicSuggestionInput.java.txt
@@ -10,6 +10,9 @@ import java.util.StringJoiner;
 )
 public class AcceptTopicSuggestionInput implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String clientMutationId;
     @javax.validation.constraints.NotNull
     private String name;

--- a/src/test/resources/expected-classes/request/AcceptTopicSuggestionInput.java.txt
+++ b/src/test/resources/expected-classes/request/AcceptTopicSuggestionInput.java.txt
@@ -10,7 +10,6 @@ import java.util.StringJoiner;
 )
 public class AcceptTopicSuggestionInput implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String clientMutationId;

--- a/src/test/resources/expected-classes/request/Event_useObjectMapperForRequestSerialization.java.txt
+++ b/src/test/resources/expected-classes/request/Event_useObjectMapperForRequestSerialization.java.txt
@@ -13,6 +13,9 @@ import java.util.StringJoiner;
 )
 public class Event implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String id;
     private String categoryId;
     private java.util.List<EventProperty> properties;

--- a/src/test/resources/expected-classes/request/Event_useObjectMapperForRequestSerialization.java.txt
+++ b/src/test/resources/expected-classes/request/Event_useObjectMapperForRequestSerialization.java.txt
@@ -13,7 +13,6 @@ import java.util.StringJoiner;
 )
 public class Event implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String id;

--- a/src/test/resources/expected-classes/resolvers/Event.java.txt
+++ b/src/test/resources/expected-classes/resolvers/Event.java.txt
@@ -10,6 +10,9 @@ package com.github.graphql;
 )
 public class Event implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String id;
     private String categoryId;
     private EventStatus status;

--- a/src/test/resources/expected-classes/resolvers/Event.java.txt
+++ b/src/test/resources/expected-classes/resolvers/Event.java.txt
@@ -10,7 +10,6 @@ package com.github.graphql;
 )
 public class Event implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String id;

--- a/src/test/resources/expected-classes/resolvers/EventProperty.java.txt
+++ b/src/test/resources/expected-classes/resolvers/EventProperty.java.txt
@@ -10,6 +10,9 @@ package com.github.graphql;
 )
 public class EventProperty implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private Double floatVal;
 
     public EventProperty() {

--- a/src/test/resources/expected-classes/resolvers/EventProperty.java.txt
+++ b/src/test/resources/expected-classes/resolvers/EventProperty.java.txt
@@ -10,7 +10,6 @@ package com.github.graphql;
 )
 public class EventProperty implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private Double floatVal;

--- a/src/test/resources/expected-classes/restricted-words/Query.java.txt
+++ b/src/test/resources/expected-classes/restricted-words/Query.java.txt
@@ -10,6 +10,9 @@ import java.util.StringJoiner;
 )
 public class Query implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String Native;
 
     public Query() {

--- a/src/test/resources/expected-classes/restricted-words/Query.java.txt
+++ b/src/test/resources/expected-classes/restricted-words/Query.java.txt
@@ -10,7 +10,6 @@ import java.util.StringJoiner;
 )
 public class Query implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String Native;

--- a/src/test/resources/expected-classes/restricted-words/Synchronized.java.txt
+++ b/src/test/resources/expected-classes/restricted-words/Synchronized.java.txt
@@ -10,6 +10,9 @@ import java.util.StringJoiner;
 )
 public class Synchronized implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     private String Void;
     private Char wait;
 

--- a/src/test/resources/expected-classes/restricted-words/Synchronized.java.txt
+++ b/src/test/resources/expected-classes/restricted-words/Synchronized.java.txt
@@ -10,7 +10,6 @@ import java.util.StringJoiner;
 )
 public class Synchronized implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private String Void;

--- a/src/test/resources/expected-classes/types-as-interfaces-extends-interface/Profile.java.txt
+++ b/src/test/resources/expected-classes/types-as-interfaces-extends-interface/Profile.java.txt
@@ -7,6 +7,9 @@ package com.github.graphql;
 )
 public class Profile implements java.io.Serializable {
 
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     @javax.validation.constraints.NotNull
     private String firstName;
     @javax.validation.constraints.NotNull

--- a/src/test/resources/expected-classes/types-as-interfaces-extends-interface/Profile.java.txt
+++ b/src/test/resources/expected-classes/types-as-interfaces-extends-interface/Profile.java.txt
@@ -7,7 +7,6 @@ package com.github.graphql;
 )
 public class Profile implements java.io.Serializable {
 
-    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @javax.validation.constraints.NotNull


### PR DESCRIPTION
---

This pull request adds a serialVersionUID to the java template _type.ftl_. This prevent warnings from for example the maven-compiler-plugin, that are raised when a class that implements Serializable does not has a serialVersionUID field.

Related to #810

---

Changes were made to:
- [x] Codegen library - Java
- [ ] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
