### PR TITLE
Added support for annotations in generated kotlin operations, fixing …

### DIFF
--- a/src/main/resources/templates/kotlin-lang/operations.ftl
+++ b/src/main/resources/templates/kotlin-lang/operations.ftl
@@ -38,7 +38,7 @@ interface ${className}<#if implements?has_content> : <#list implements as interf
     <#if operation.throwsException>
     @Throws(Exception::class)
     </#if>
-    fun ${operation.name}(<#list operation.parameters as param>${param.name}: ${param.type}<#if param_has_next>, </#if></#list>): ${operation.type}
+    fun ${operation.name}(<#list operation.parameters as param><#list param.annotations as paramAnnotation>@${paramAnnotation}<#if param.annotations?has_content> </#if></#list>${param.name}: ${param.type}<#if param_has_next>, </#if></#list>): ${operation.type}
 
 </#list>
 }

--- a/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenGitHubTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenGitHubTest.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 
 import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent;
 import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -186,6 +187,26 @@ class GraphQLCodegenGitHubTest {
                         "src/test/resources/expected-classes/kt/field-resolver/" +
                                 "AcceptTopicSuggestionPayloadResolver.kt.txt"),
                 getFileByName(files, "AcceptTopicSuggestionPayloadResolver.kt"));
+    }
+
+    @Test
+    void generate_CustomFieldsResolversWithAnnotations() throws Exception {
+        mappingConfig.setModelNamePrefix("Github");
+        mappingConfig.setModelNameSuffix("TO");
+        mappingConfig.setApiNameSuffix("WithAnnotation");
+        mappingConfig.setResolverArgumentAnnotations(singleton("some.Annotation"));
+        mappingConfig.setGenerateDataFetchingEnvironmentArgumentInApis(true);
+        mappingConfig.setFieldsWithResolvers(Collections.singleton("AcceptTopicSuggestionPayload.topic"));
+
+        new KotlinGraphQLCodegen(singletonList("src/test/resources/schemas/github.graphqls"),
+                outputBuildDir, mappingConfig, TestUtils.getStaticGeneratedInfo()).generate();
+
+        File[] files = Objects.requireNonNull(outputktClassesDir.listFiles());
+
+        assertSameTrimmedContent(new File(
+                        "src/test/resources/expected-classes/kt/field-resolver/" +
+                                "AcceptTopicSuggestionMutationWithAnnotation.kt.txt"),
+                getFileByName(files, "AcceptTopicSuggestionMutationWithAnnotation.kt"));
     }
 
     @Test

--- a/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenGitHubTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenGitHubTest.java
@@ -12,7 +12,9 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent;
 import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
@@ -190,7 +192,7 @@ class GraphQLCodegenGitHubTest {
     }
 
     @Test
-    void generate_CustomFieldsResolversWithAnnotations() throws Exception {
+    void generate_CustomFieldsResolversWithAnnotation() throws Exception {
         mappingConfig.setModelNamePrefix("Github");
         mappingConfig.setModelNameSuffix("TO");
         mappingConfig.setApiNameSuffix("WithAnnotation");
@@ -207,6 +209,31 @@ class GraphQLCodegenGitHubTest {
                         "src/test/resources/expected-classes/kt/field-resolver/" +
                                 "AcceptTopicSuggestionMutationWithAnnotation.kt.txt"),
                 getFileByName(files, "AcceptTopicSuggestionMutationWithAnnotation.kt"));
+    }
+
+    @Test
+    void generate_CustomFieldsResolversWithMultipleAnnotations() throws Exception {
+
+        Set<String> annotations = new HashSet<>();
+        annotations.add("some.Annotation");
+        annotations.add("another.Annotation");
+
+        mappingConfig.setModelNamePrefix("Github");
+        mappingConfig.setModelNameSuffix("TO");
+        mappingConfig.setApiNameSuffix("WithAnnotations");
+        mappingConfig.setResolverArgumentAnnotations(annotations);
+        mappingConfig.setGenerateDataFetchingEnvironmentArgumentInApis(true);
+        mappingConfig.setFieldsWithResolvers(Collections.singleton("AcceptTopicSuggestionPayload.topic"));
+
+        new KotlinGraphQLCodegen(singletonList("src/test/resources/schemas/github.graphqls"),
+                outputBuildDir, mappingConfig, TestUtils.getStaticGeneratedInfo()).generate();
+
+        File[] files = Objects.requireNonNull(outputktClassesDir.listFiles());
+
+        assertSameTrimmedContent(new File(
+                        "src/test/resources/expected-classes/kt/field-resolver/" +
+                                "AcceptTopicSuggestionMutationWithAnnotations.kt.txt"),
+                getFileByName(files, "AcceptTopicSuggestionMutationWithAnnotations.kt"));
     }
 
     @Test

--- a/src/test/resources/expected-classes/kt/field-resolver/AcceptTopicSuggestionMutationWithAnnotation.kt.txt
+++ b/src/test/resources/expected-classes/kt/field-resolver/AcceptTopicSuggestionMutationWithAnnotation.kt.txt
@@ -1,0 +1,13 @@
+package com.github.graphql
+
+
+@javax.annotation.Generated(
+    value = ["com.kobylynskyi.graphql.codegen.GraphQLCodegen"],
+    date = "2020-12-31T23:59:59-0500"
+)
+interface AcceptTopicSuggestionMutationWithAnnotation {
+
+    @Throws(Exception::class)
+    fun acceptTopicSuggestion(@some.Annotation input: GithubAcceptTopicSuggestionInputTO, env: graphql.schema.DataFetchingEnvironment): GithubAcceptTopicSuggestionPayloadTO?
+
+}

--- a/src/test/resources/expected-classes/kt/field-resolver/AcceptTopicSuggestionMutationWithAnnotations.kt.txt
+++ b/src/test/resources/expected-classes/kt/field-resolver/AcceptTopicSuggestionMutationWithAnnotations.kt.txt
@@ -1,0 +1,13 @@
+package com.github.graphql
+
+
+@javax.annotation.Generated(
+    value = ["com.kobylynskyi.graphql.codegen.GraphQLCodegen"],
+    date = "2020-12-31T23:59:59-0500"
+)
+interface AcceptTopicSuggestionMutationWithAnnotations {
+
+    @Throws(Exception::class)
+    fun acceptTopicSuggestion(@another.Annotation @some.Annotation input: GithubAcceptTopicSuggestionInputTO, env: graphql.schema.DataFetchingEnvironment): GithubAcceptTopicSuggestionPayloadTO?
+
+}


### PR DESCRIPTION
Proposed fix for #1002

---

### Description

Fixes annotations not being added to Kotlin resolver parameters as discussed in #1002 through freemarker template changes (and an associated test).

---

Changes were made to:
- [ ] Codegen library - Java
- [x] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
