### PR TITLE
Support UUIDs

### DIFF
--- a/src/main/java/com/kobylynskyi/graphql/codegen/model/graphql/GraphQLRequestSerializer.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/model/graphql/GraphQLRequestSerializer.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.UUID;
 
 /**
  * Serializer of GraphQL request.
@@ -144,6 +145,10 @@ public class GraphQLRequestSerializer {
 
     public static String getEntry(Object input) {
         return getEntry(input, false);
+    }
+
+    public static String getEntry( UUID input ) {
+        return getEntry( input, true );
     }
 
     /**


### PR DESCRIPTION
---

### Description

If the schema contains an `UUID` scalar when `GraphQLRequestSerializer.toQueryString()` is called the UUID value will not be between quotes which generates an invalid request.

---

Changes were made to:
- [ ] Codegen library - Java
- [ ] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
