### PR TITLE
Add resolver argument annotation on parameterized field resolvers

### DIFF
--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/AnnotationsMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/AnnotationsMapper.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.kobylynskyi.graphql.codegen.mapper.GraphQLTypeMapper.getDirectives;
 import static com.kobylynskyi.graphql.codegen.mapper.GraphQLTypeMapper.getMandatoryType;
@@ -123,9 +124,12 @@ public abstract class AnnotationsMapper {
             }
         }
         // 6. Add annotations for resolver arguments
-        if (!Utils.isEmpty(mappingContext.getResolverArgumentAnnotations())
-                && mappingContext.getOperationsName().contains(parentTypeName)) {
-            annotations.addAll(mappingContext.getResolverArgumentAnnotations());
+        if (!Utils.isEmpty(mappingContext.getResolverArgumentAnnotations())) {
+            if (mappingContext.getOperationsName().contains(parentTypeName)
+                || (def instanceof InputValueDefinition
+                && !mappingContext.getInputsName().contains(parentTypeName))) {
+                annotations.addAll(mappingContext.getResolverArgumentAnnotations());
+            }
         }
         // 7. Add annotations for parametrized resolvers
         if (!Utils.isEmpty(mappingContext.getParametrizedResolverAnnotations())

--- a/src/main/java/com/kobylynskyi/graphql/codegen/model/MappingContext.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/model/MappingContext.java
@@ -31,6 +31,7 @@ public class MappingContext implements GraphQLCodegenConfiguration {
     private final Set<String> interfacesName;
     private final Set<String> unionsName;
     private final Set<String> operationsName;
+    private final Set<String> inputsName;
     private final Map<String, Set<String>> interfaceChildren;
     private final GeneratedInformation generatedInformation;
     private final DataModelMapperFactory dataModelMapperFactory;
@@ -49,6 +50,8 @@ public class MappingContext implements GraphQLCodegenConfiguration {
         this.typesUnionsInterfacesNames = document.getTypesUnionsInterfacesNames();
         this.interfacesName = document.getInterfacesNames();
         this.unionsName = document.getUnionsNames();
+        this.inputsName = document.getInputDefinitions().stream().map(ExtendedDefinition::getName)
+                .collect(Collectors.toSet());
         this.interfaceChildren = document.getInterfaceChildren();
         this.generatedInformation = generatedInformation;
         this.operationsName = document.getOperationsNames();
@@ -364,6 +367,10 @@ public class MappingContext implements GraphQLCodegenConfiguration {
 
     public Set<String> getOperationsName() {
         return operationsName;
+    }
+
+    public Set<String> getInputsName() {
+        return inputsName;
     }
 
     public Map<String, Set<String>> getInterfaceChildren() {

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenAnnotationsTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenAnnotationsTest.java
@@ -200,6 +200,7 @@ class GraphQLCodegenAnnotationsTest {
     @Test
     void generate_ResolverArgumentAnnotations() throws Exception {
         mappingConfig.setGenerateDataFetchingEnvironmentArgumentInApis(true);
+        mappingConfig.setGenerateParameterizedFieldsResolvers(true);
         mappingConfig.setResolverArgumentAnnotations(singleton(
                 "@org.springframework.graphql.data.method.annotation.Argument"));
 
@@ -212,6 +213,9 @@ class GraphQLCodegenAnnotationsTest {
         assertSameTrimmedContent(
                 new File("src/test/resources/expected-classes/annotation/QueryResolver_ArgumentAnnotations.java.txt"),
                 getFileByName(files, "QueryResolver.java"));
+        assertSameTrimmedContent(new File("src/test/resources/expected-classes/annotation/" +
+                        "EventPropertyResolver_ArgumentAnnotations.java.txt"),
+                getFileByName(files, "EventPropertyResolver.java"));
     }
 
     @Test

--- a/src/test/resources/expected-classes/annotation/EventPropertyResolver_ArgumentAnnotations.java.txt
+++ b/src/test/resources/expected-classes/annotation/EventPropertyResolver_ArgumentAnnotations.java.txt
@@ -13,11 +13,11 @@ public interface EventPropertyResolver {
     /**
      * Properties
      */
-    java.util.List<EventProperty> child(EventProperty eventProperty, Integer first, Integer last, graphql.schema.DataFetchingEnvironment env) throws Exception;
+    java.util.List<EventProperty> child(EventProperty eventProperty, @org.springframework.graphql.data.method.annotation.Argument Integer first, @org.springframework.graphql.data.method.annotation.Argument Integer last, graphql.schema.DataFetchingEnvironment env) throws Exception;
 
     /**
      * Parent event of the property
      */
-    Event parent(EventProperty eventProperty, EventStatus withStatus, String createdAfter, graphql.schema.DataFetchingEnvironment env) throws Exception;
+    Event parent(EventProperty eventProperty, @org.springframework.graphql.data.method.annotation.Argument EventStatus withStatus, @org.springframework.graphql.data.method.annotation.Argument String createdAfter, graphql.schema.DataFetchingEnvironment env) throws Exception;
 
 }

--- a/src/test/resources/expected-classes/annotation/EventPropertyResolver_ArgumentAnnotations.java.txt
+++ b/src/test/resources/expected-classes/annotation/EventPropertyResolver_ArgumentAnnotations.java.txt
@@ -1,0 +1,23 @@
+package com.kobylynskyi.graphql.test1;
+
+
+/**
+ * Resolver for EventProperty
+ */
+@javax.annotation.Generated(
+    value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+    date = "2020-12-31T23:59:59-0500"
+)
+public interface EventPropertyResolver {
+
+    /**
+     * Properties
+     */
+    java.util.List<EventProperty> child(EventProperty eventProperty, Integer first, Integer last, graphql.schema.DataFetchingEnvironment env) throws Exception;
+
+    /**
+     * Parent event of the property
+     */
+    Event parent(EventProperty eventProperty, EventStatus withStatus, String createdAfter, graphql.schema.DataFetchingEnvironment env) throws Exception;
+
+}


### PR DESCRIPTION
---

### Description

Currently, the resolver argument annotation is not applied on parameterized field resolver, which is problematic when using this generator to apply the  org.springframework.graphql.data.method.annotation.Argument necessary to work with spring boot graphql integration.

This contains a commit that only adds a assertion file to demonstrate the issue, and another to fix it.

---

Changes were made to:
- [X] Codegen library - Java
- [X] Codegen library - Kotlin
- [X] Codegen library - Scala
