### PR TITLE
fix: Updated dependencies to resolve security vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ repositories {
 
 dependencies {
     compileOnly "org.freemarker:freemarker:2.3.31"
-    compileOnly "com.graphql-java:graphql-java:16.2"
-    compileOnly "com.fasterxml.jackson.core:jackson-databind:2.13.3"
+    compileOnly "com.graphql-java:graphql-java:20.0"
+    compileOnly "com.fasterxml.jackson.core:jackson-databind:2.14.2"
     compileOnly "com.typesafe:config:1.4.1"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.1"

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenAnnotationsTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenAnnotationsTest.java
@@ -6,6 +6,7 @@ import com.kobylynskyi.graphql.codegen.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,6 +23,7 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenAnnotationsTest {
 
     private final File outputBuildDir = new File("build/generated");

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenApisTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenApisTest.java
@@ -10,6 +10,7 @@ import com.kobylynskyi.graphql.codegen.supplier.SchemaFinder;
 import com.kobylynskyi.graphql.codegen.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,6 +29,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenApisTest {
 
     private final File outputBuildDir = new File("build/generated");

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenFieldsResolversTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenFieldsResolversTest.java
@@ -6,6 +6,7 @@ import com.kobylynskyi.graphql.codegen.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,6 +19,7 @@ import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenFieldsResolversTest {
 
     private final File outputBuildDir = new File("build/generated");

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenGitHubTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenGitHubTest.java
@@ -7,6 +7,7 @@ import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -17,6 +18,7 @@ import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenGitHubTest {
 
     private final File outputBuildDir = new File("build/generated");

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenOptionalTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenOptionalTest.java
@@ -7,6 +7,7 @@ import com.kobylynskyi.graphql.codegen.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,6 +17,7 @@ import java.util.Objects;
 import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent;
 import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenOptionalTest {
 
     private final File outputBuildDir = new File("build/generated");

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenRequestTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenRequestTest.java
@@ -6,6 +6,7 @@ import com.kobylynskyi.graphql.codegen.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -17,6 +18,7 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenRequestTest {
 
     private final File outputBuildDir = new File("build/generated");

--- a/src/test/java/com/kobylynskyi/graphql/codegen/MaxQueryTokensExtension.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/MaxQueryTokensExtension.java
@@ -1,0 +1,27 @@
+package com.kobylynskyi.graphql.codegen;
+
+import graphql.parser.ParserOptions;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * This extension is to increase the {@link ParserOptions#MAX_QUERY_TOKENS}} to 20_000 JVM wide
+ * to allow successful test schema parsing
+ */
+public class MaxQueryTokensExtension implements BeforeAllCallback, AfterAllCallback {
+
+    private static final ParserOptions defaultJvmParserOptions = ParserOptions.getDefaultParserOptions();
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        ParserOptions.setDefaultParserOptions(
+                ParserOptions.getDefaultParserOptions().transform(o -> o.maxTokens(20_000))
+        );
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        ParserOptions.setDefaultParserOptions(defaultJvmParserOptions);
+    }
+}

--- a/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenGitHubTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenGitHubTest.java
@@ -1,5 +1,6 @@
 package com.kobylynskyi.graphql.codegen.kotlin;
 
+import com.kobylynskyi.graphql.codegen.MaxQueryTokensExtension;
 import com.kobylynskyi.graphql.codegen.TestUtils;
 import com.kobylynskyi.graphql.codegen.model.GeneratedLanguage;
 import com.kobylynskyi.graphql.codegen.model.MappingConfig;
@@ -7,6 +8,7 @@ import com.kobylynskyi.graphql.codegen.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,6 +23,7 @@ import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenGitHubTest {
 
     private final File outputBuildDir = new File("build/generated");

--- a/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenInitializeNullableTypesTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenInitializeNullableTypesTest.java
@@ -1,5 +1,6 @@
 package com.kobylynskyi.graphql.codegen.kotlin;
 
+import com.kobylynskyi.graphql.codegen.MaxQueryTokensExtension;
 import com.kobylynskyi.graphql.codegen.TestUtils;
 import com.kobylynskyi.graphql.codegen.model.GeneratedLanguage;
 import com.kobylynskyi.graphql.codegen.model.MappingConfig;
@@ -7,6 +8,7 @@ import com.kobylynskyi.graphql.codegen.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.util.Objects;
@@ -15,6 +17,7 @@ import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent
 import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
 import static java.util.Collections.singletonList;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenInitializeNullableTypesTest {
 
     private final File outputBuildDir = new File("build/generated");

--- a/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenOpenclassesTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenOpenclassesTest.java
@@ -1,5 +1,6 @@
 package com.kobylynskyi.graphql.codegen.kotlin;
 
+import com.kobylynskyi.graphql.codegen.MaxQueryTokensExtension;
 import com.kobylynskyi.graphql.codegen.TestUtils;
 import com.kobylynskyi.graphql.codegen.model.GeneratedLanguage;
 import com.kobylynskyi.graphql.codegen.model.MappingConfig;
@@ -7,6 +8,7 @@ import com.kobylynskyi.graphql.codegen.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.util.Objects;
@@ -15,6 +17,7 @@ import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent
 import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
 import static java.util.Collections.singletonList;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenOpenclassesTest {
 
     private final File outputBuildDir = new File("build/generated");

--- a/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenSealedInterfacesTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenSealedInterfacesTest.java
@@ -1,5 +1,6 @@
 package com.kobylynskyi.graphql.codegen.kotlin;
 
+import com.kobylynskyi.graphql.codegen.MaxQueryTokensExtension;
 import com.kobylynskyi.graphql.codegen.TestUtils;
 import com.kobylynskyi.graphql.codegen.model.GeneratedLanguage;
 import com.kobylynskyi.graphql.codegen.model.MappingConfig;
@@ -7,6 +8,7 @@ import com.kobylynskyi.graphql.codegen.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.util.Objects;
@@ -15,6 +17,7 @@ import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent
 import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
 import static java.util.Collections.singletonList;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenSealedInterfacesTest {
     private final File outputBuildDir = new File("build/generated");
     private final File outputScalaClassesDir = new File("build/generated/com/github/graphql");

--- a/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenAnnotationsTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenAnnotationsTest.java
@@ -1,5 +1,6 @@
 package com.kobylynskyi.graphql.codegen.scala;
 
+import com.kobylynskyi.graphql.codegen.MaxQueryTokensExtension;
 import com.kobylynskyi.graphql.codegen.TestUtils;
 import com.kobylynskyi.graphql.codegen.model.GeneratedLanguage;
 import com.kobylynskyi.graphql.codegen.model.MappingConfig;
@@ -7,6 +8,7 @@ import com.kobylynskyi.graphql.codegen.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,6 +24,7 @@ import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenAnnotationsTest {
 
     private final File outputBuildDir = new File("build/generated");

--- a/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenGitHubTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenGitHubTest.java
@@ -1,5 +1,6 @@
 package com.kobylynskyi.graphql.codegen.scala;
 
+import com.kobylynskyi.graphql.codegen.MaxQueryTokensExtension;
 import com.kobylynskyi.graphql.codegen.TestUtils;
 import com.kobylynskyi.graphql.codegen.model.GeneratedLanguage;
 import com.kobylynskyi.graphql.codegen.model.MappingConfig;
@@ -8,6 +9,7 @@ import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,6 +20,7 @@ import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenGitHubTest {
 
     private final File outputBuildDir = new File("build/generated");

--- a/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenOpenclassesTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenOpenclassesTest.java
@@ -1,5 +1,6 @@
 package com.kobylynskyi.graphql.codegen.scala;
 
+import com.kobylynskyi.graphql.codegen.MaxQueryTokensExtension;
 import com.kobylynskyi.graphql.codegen.TestUtils;
 import com.kobylynskyi.graphql.codegen.model.GeneratedLanguage;
 import com.kobylynskyi.graphql.codegen.model.MappingConfig;
@@ -7,6 +8,7 @@ import com.kobylynskyi.graphql.codegen.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,6 +18,7 @@ import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent
 import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
 import static java.util.Collections.singletonList;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenOpenclassesTest {
 
     private final File outputBuildDir = new File("build/generated");

--- a/src/test/resources/expected-classes/from-introspection-result/StockStatus.java.txt
+++ b/src/test/resources/expected-classes/from-introspection-result/StockStatus.java.txt
@@ -6,11 +6,29 @@ package com.kobylynskyi.graphql.test1;
 )
 public enum StockStatus {
 
+    /**
+     * 
+     */
     IN_STOCK("IN_STOCK"),
+    /**
+     * 
+     */
     SPECIAL_ORDER("SPECIAL_ORDER"),
+    /**
+     * 
+     */
     BACK_ORDERED("BACK_ORDERED"),
+    /**
+     * 
+     */
     COMING_SOON("COMING_SOON"),
+    /**
+     * 
+     */
     SOLD_OUT("SOLD_OUT"),
+    /**
+     * 
+     */
     DISCONTINUED("DISCONTINUED");
 
     private final String graphqlName;


### PR DESCRIPTION
---

### Description

Related to #1045 

Updated following dependencies to resolve security vulnerabilities
- `com.graphql-java:graphql-java`
- `com.fasterxml.jackson.core:jackson-databind`
Updated unit tests to be able to parse test schemas with more tokens than the default size(15000) 

---

Changes were made to:
- [ ] Codegen library - Java
- [ ] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
- [x] Dependencies 
