### PR TITLE
fix: updated unit test with increased max query tokens

### DIFF
--- a/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenSealedInterfacesTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenSealedInterfacesTest.java
@@ -1,13 +1,14 @@
 package com.kobylynskyi.graphql.codegen.scala;
 
+import com.kobylynskyi.graphql.codegen.MaxQueryTokensExtension;
 import com.kobylynskyi.graphql.codegen.TestUtils;
-import com.kobylynskyi.graphql.codegen.kotlin.KotlinGraphQLCodegen;
 import com.kobylynskyi.graphql.codegen.model.GeneratedLanguage;
 import com.kobylynskyi.graphql.codegen.model.MappingConfig;
 import com.kobylynskyi.graphql.codegen.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.util.Objects;
@@ -16,6 +17,7 @@ import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent
 import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
 import static java.util.Collections.singletonList;
 
+@ExtendWith(MaxQueryTokensExtension.class)
 class GraphQLCodegenSealedInterfacesTest {
     private final File outputBuildDir = new File("build/generated");
     private final File outputScalaClassesDir = new File("build/generated/com/github/graphql");


### PR DESCRIPTION
This is as a result of PR#1046 that has upgraded graphql-java to 20.0

---

### Description

Related to #1046 
Fixed broken unit test

---

Changes were made to:
- [ ] Codegen library - Java
- [ ] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
- [x] Fix broken unit test
