### PR TITLE
fixes #1154

### DIFF
--- a/src/main/resources/templates/java-lang/type.ftl
+++ b/src/main/resources/templates/java-lang/type.ftl
@@ -197,7 +197,7 @@ public class ${className} implements java.io.Serializable<#if implements?has_con
 
         public ${className} build() {
 <#if generateNoArgsConstructorOnly>
-            ${className} result = new ${className};
+            ${className} result = new ${className}();
     <#list fields as field>
         <#if field.visibility == 'public'>
             result.${field.name}(this.${field.name});

--- a/src/test/resources/expected-classes/no-args-constructor/Event_noargsconstr_builder.java.txt
+++ b/src/test/resources/expected-classes/no-args-constructor/Event_noargsconstr_builder.java.txt
@@ -143,7 +143,7 @@ public class Event implements java.io.Serializable {
 
 
         public Event build() {
-            Event result = new Event;
+            Event result = new Event();
             result.setId(this.id);
             result.setCategoryId(this.categoryId);
             result.setProperties(this.properties);

--- a/src/test/resources/expected-classes/public-fields/Event_publicfields_builder_noargsconstr.java.txt
+++ b/src/test/resources/expected-classes/public-fields/Event_publicfields_builder_noargsconstr.java.txt
@@ -118,7 +118,7 @@ public class Event implements java.io.Serializable {
 
 
         public Event build() {
-            Event result = new Event;
+            Event result = new Event();
             result.id(this.id);
             result.categoryId(this.categoryId);
             result.properties(this.properties);


### PR DESCRIPTION
---

### Description
Fixes non-compileable classes when setting `generateNoArgsConstructorOnly` to `true`
Related to #1154
---

Changes were made to:
- [x] Codegen library - Java
- [ ] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
