### PR TITLE
Added `@Generated` annotation to builder class

### DIFF
--- a/src/main/resources/templates/java-lang/request.ftl
+++ b/src/main/resources/templates/java-lang/request.ftl
@@ -122,6 +122,12 @@ public class ${className} implements GraphQLOperationRequest {
         return new ${className}.Builder();
     }
 
+    <#if generatedAnnotation && generatedInfo.getGeneratedType()?has_content>
+    @${generatedInfo.getGeneratedType()}(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "${generatedInfo.getDateTime()}"
+    )
+    </#if>
     public static class Builder {
 
         private String $alias;

--- a/src/main/resources/templates/java-lang/type.ftl
+++ b/src/main/resources/templates/java-lang/type.ftl
@@ -164,6 +164,12 @@ public class ${className} implements java.io.Serializable<#if implements?has_con
         return new ${className}.Builder();
     }
 
+    <#if generatedAnnotation && generatedInfo.getGeneratedType()?has_content>
+    @${generatedInfo.getGeneratedType()}(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "${generatedInfo.getDateTime()}"
+    )
+    </#if>
     public static class Builder {
 
     <#if fields?has_content>

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenAnnotationsTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenAnnotationsTest.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import static com.kobylynskyi.graphql.codegen.TestUtils.assertFileContainsElements;
 import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent;
 import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
+import static java.lang.System.lineSeparator;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -85,7 +86,7 @@ class GraphQLCodegenAnnotationsTest {
 
         File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
         assertFileContainsElements(files, "ReproInput.java",
-                "    @com.fasterxml.jackson.annotation.JsonProperty(\"reproField\")\n" +
+                "    @com.fasterxml.jackson.annotation.JsonProperty(\"reproField\")" + lineSeparator() +
                         "    private java.util.List<String> reproField;");
     }
 

--- a/src/test/resources/expected-classes/Commit.java.txt
+++ b/src/test/resources/expected-classes/Commit.java.txt
@@ -388,6 +388,10 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         return new Commit.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String abbreviatedOid;

--- a/src/test/resources/expected-classes/Event.java.txt
+++ b/src/test/resources/expected-classes/Event.java.txt
@@ -97,6 +97,10 @@ public class Event implements java.io.Serializable {
         return new Event.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String id;

--- a/src/test/resources/expected-classes/EventProperty.java.txt
+++ b/src/test/resources/expected-classes/EventProperty.java.txt
@@ -120,6 +120,10 @@ public class EventProperty implements java.io.Serializable {
         return new EventProperty.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Double floatVal;

--- a/src/test/resources/expected-classes/EventPropertyTO_toString.java.txt
+++ b/src/test/resources/expected-classes/EventPropertyTO_toString.java.txt
@@ -145,6 +145,10 @@ public class EventPropertyTO implements java.io.Serializable {
         return new EventPropertyTO.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Double floatVal;

--- a/src/test/resources/expected-classes/EventPropertyTO_withEqualsAndHashCode.java.txt
+++ b/src/test/resources/expected-classes/EventPropertyTO_withEqualsAndHashCode.java.txt
@@ -143,6 +143,10 @@ public class EventPropertyTO implements java.io.Serializable {
         return new EventPropertyTO.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Double floatVal;

--- a/src/test/resources/expected-classes/GithubAcceptTopicSuggestionInputTO.java.txt
+++ b/src/test/resources/expected-classes/GithubAcceptTopicSuggestionInputTO.java.txt
@@ -51,6 +51,10 @@ public class GithubAcceptTopicSuggestionInputTO implements java.io.Serializable 
         return new GithubAcceptTopicSuggestionInputTO.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String clientMutationId;

--- a/src/test/resources/expected-classes/GithubAcceptTopicSuggestionPayloadTO.java.txt
+++ b/src/test/resources/expected-classes/GithubAcceptTopicSuggestionPayloadTO.java.txt
@@ -31,6 +31,10 @@ public class GithubAcceptTopicSuggestionPayloadTO implements java.io.Serializabl
         return new GithubAcceptTopicSuggestionPayloadTO.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String clientMutationId;

--- a/src/test/resources/expected-classes/GithubCommitTO.java.txt
+++ b/src/test/resources/expected-classes/GithubCommitTO.java.txt
@@ -388,6 +388,10 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         return new GithubCommitTO.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String abbreviatedOid;

--- a/src/test/resources/expected-classes/Person.java.txt
+++ b/src/test/resources/expected-classes/Person.java.txt
@@ -52,6 +52,10 @@ public class Person implements java.io.Serializable, NamedEntity {
         return new Person.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String name;

--- a/src/test/resources/expected-classes/Person1.java.txt
+++ b/src/test/resources/expected-classes/Person1.java.txt
@@ -55,6 +55,10 @@ public class Person implements java.io.Serializable, NamedEntity {
         return new Person.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String name;

--- a/src/test/resources/expected-classes/UnionMember1.java.txt
+++ b/src/test/resources/expected-classes/UnionMember1.java.txt
@@ -31,6 +31,10 @@ public class UnionMember1 implements java.io.Serializable, MyUnion {
         return new UnionMember1.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Integer someField;

--- a/src/test/resources/expected-classes/UnionMember2.java.txt
+++ b/src/test/resources/expected-classes/UnionMember2.java.txt
@@ -31,6 +31,10 @@ public class UnionMember2 implements java.io.Serializable, MyUnion {
         return new UnionMember2.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String someField;

--- a/src/test/resources/expected-classes/User.java.txt
+++ b/src/test/resources/expected-classes/User.java.txt
@@ -43,6 +43,10 @@ public class User implements java.io.Serializable {
         return new User.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String name;

--- a/src/test/resources/expected-classes/annotation/Commit_noValidationAnnotation.java.txt
+++ b/src/test/resources/expected-classes/annotation/Commit_noValidationAnnotation.java.txt
@@ -364,6 +364,10 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         return new Commit.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String abbreviatedOid;

--- a/src/test/resources/expected-classes/annotation/EventProperty.java.txt
+++ b/src/test/resources/expected-classes/annotation/EventProperty.java.txt
@@ -121,6 +121,10 @@ public class EventProperty implements java.io.Serializable {
         return new EventProperty.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Double floatVal;

--- a/src/test/resources/expected-classes/annotation/TypeWithNullableListType.java.txt
+++ b/src/test/resources/expected-classes/annotation/TypeWithNullableListType.java.txt
@@ -37,6 +37,10 @@ public class TypeWithNullableListType implements java.io.Serializable {
         return new TypeWithNullableListType.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private java.util.List<Type2> nullableListFieldWithMandatoryElements;

--- a/src/test/resources/expected-classes/annotation/User.java.txt
+++ b/src/test/resources/expected-classes/annotation/User.java.txt
@@ -44,6 +44,10 @@ public class User implements java.io.Serializable {
         return new User.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String name;

--- a/src/test/resources/expected-classes/custom-type/QueryINeedQueryRequest.java.txt
+++ b/src/test/resources/expected-classes/custom-type/QueryINeedQueryRequest.java.txt
@@ -66,6 +66,10 @@ public class QueryINeedQueryRequest implements GraphQLOperationRequest {
         return new QueryINeedQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/custom-type/ResponseContainingDate.java.txt
+++ b/src/test/resources/expected-classes/custom-type/ResponseContainingDate.java.txt
@@ -41,6 +41,10 @@ public class ResponseContainingDate implements java.io.Serializable {
         return new ResponseContainingDate.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private java.time.ZonedDateTime a;

--- a/src/test/resources/expected-classes/defaults/InputWithDefaults.java.txt
+++ b/src/test/resources/expected-classes/defaults/InputWithDefaults.java.txt
@@ -126,6 +126,10 @@ public class InputWithDefaults implements java.io.Serializable {
         return new InputWithDefaults.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Double floatVal = 1.23;

--- a/src/test/resources/expected-classes/defaults/InputWithDefaultsDTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/InputWithDefaultsDTO.java.txt
@@ -135,6 +135,10 @@ public class InputWithDefaultsDTO implements java.io.Serializable {
         return new InputWithDefaultsDTO.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Double floatVal = 1.23;

--- a/src/test/resources/expected-classes/defaults/InputWithDefaultsTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/InputWithDefaultsTO.java.txt
@@ -126,6 +126,10 @@ public class InputWithDefaultsTO implements java.io.Serializable {
         return new InputWithDefaultsTO.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Double floatVal = 1.23;

--- a/src/test/resources/expected-classes/defaults/SomeObject.java.txt
+++ b/src/test/resources/expected-classes/defaults/SomeObject.java.txt
@@ -32,6 +32,10 @@ public class SomeObject implements java.io.Serializable {
         return new SomeObject.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String name;

--- a/src/test/resources/expected-classes/defaults/SomeObjectDTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/SomeObjectDTO.java.txt
@@ -32,6 +32,10 @@ public class SomeObjectDTO implements java.io.Serializable {
         return new SomeObjectDTO.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String name;

--- a/src/test/resources/expected-classes/defaults/SomeObjectTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/SomeObjectTO.java.txt
@@ -32,6 +32,10 @@ public class SomeObjectTO implements java.io.Serializable {
         return new SomeObjectTO.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String name;

--- a/src/test/resources/expected-classes/deprecated/Event.java.txt
+++ b/src/test/resources/expected-classes/deprecated/Event.java.txt
@@ -61,6 +61,10 @@ public class Event implements java.io.Serializable, PinnableItem, Node {
         return new Event.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Status status;

--- a/src/test/resources/expected-classes/deprecated/EventInput.java.txt
+++ b/src/test/resources/expected-classes/deprecated/EventInput.java.txt
@@ -35,6 +35,10 @@ public class EventInput implements java.io.Serializable {
         return new EventInput.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Status status;

--- a/src/test/resources/expected-classes/empty/Event.java.txt
+++ b/src/test/resources/expected-classes/empty/Event.java.txt
@@ -17,6 +17,10 @@ public class Event implements java.io.Serializable {
         return new Event.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
 

--- a/src/test/resources/expected-classes/empty/EventInput.java.txt
+++ b/src/test/resources/expected-classes/empty/EventInput.java.txt
@@ -17,6 +17,10 @@ public class EventInput implements java.io.Serializable {
         return new EventInput.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
 

--- a/src/test/resources/expected-classes/extend-with-resolvers/Asset.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/Asset.java.txt
@@ -49,6 +49,10 @@ public class Asset implements java.io.Serializable, PinnableItem, Node {
         return new Asset.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String name;

--- a/src/test/resources/expected-classes/extend-with-resolvers/AssetInput.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/AssetInput.java.txt
@@ -29,6 +29,10 @@ public class AssetInput implements java.io.Serializable {
         return new AssetInput.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String name;

--- a/src/test/resources/expected-classes/extend-with-resolvers/Event.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/Event.java.txt
@@ -49,6 +49,10 @@ public class Event implements java.io.Serializable, PinnableItem, Node {
         return new Event.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Status status;

--- a/src/test/resources/expected-classes/extend-with-resolvers/EventInput.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/EventInput.java.txt
@@ -38,6 +38,10 @@ public class EventInput implements java.io.Serializable {
         return new EventInput.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Status status;

--- a/src/test/resources/expected-classes/extend/Asset.java.txt
+++ b/src/test/resources/expected-classes/extend/Asset.java.txt
@@ -58,6 +58,10 @@ public class Asset implements java.io.Serializable, PinnableItem, Node {
         return new Asset.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String name;

--- a/src/test/resources/expected-classes/extend/AssetInput.java.txt
+++ b/src/test/resources/expected-classes/extend/AssetInput.java.txt
@@ -29,6 +29,10 @@ public class AssetInput implements java.io.Serializable {
         return new AssetInput.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String name;

--- a/src/test/resources/expected-classes/extend/Event.java.txt
+++ b/src/test/resources/expected-classes/extend/Event.java.txt
@@ -73,6 +73,10 @@ public class Event implements java.io.Serializable, PinnableItem, Node {
         return new Event.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Status status;

--- a/src/test/resources/expected-classes/extend/EventInput.java.txt
+++ b/src/test/resources/expected-classes/extend/EventInput.java.txt
@@ -38,6 +38,10 @@ public class EventInput implements java.io.Serializable {
         return new EventInput.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Status status;

--- a/src/test/resources/expected-classes/from-introspection-result/CreateMutationRequest.java.txt
+++ b/src/test/resources/expected-classes/from-introspection-result/CreateMutationRequest.java.txt
@@ -66,6 +66,10 @@ public class CreateMutationRequest implements GraphQLOperationRequest {
         return new CreateMutationRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/from-introspection-result/Product.java.txt
+++ b/src/test/resources/expected-classes/from-introspection-result/Product.java.txt
@@ -118,6 +118,10 @@ public class Product implements java.io.Serializable {
         return new Product.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String id;

--- a/src/test/resources/expected-classes/from-introspection-result/ProductByIdQueryRequest.java.txt
+++ b/src/test/resources/expected-classes/from-introspection-result/ProductByIdQueryRequest.java.txt
@@ -66,6 +66,10 @@ public class ProductByIdQueryRequest implements GraphQLOperationRequest {
         return new ProductByIdQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/from-introspection-result/ProductInput.java.txt
+++ b/src/test/resources/expected-classes/from-introspection-result/ProductInput.java.txt
@@ -92,6 +92,10 @@ public class ProductInput implements java.io.Serializable {
         return new ProductInput.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String title;

--- a/src/test/resources/expected-classes/from-introspection-result/ProductsByIdsQueryRequest.java.txt
+++ b/src/test/resources/expected-classes/from-introspection-result/ProductsByIdsQueryRequest.java.txt
@@ -66,6 +66,10 @@ public class ProductsByIdsQueryRequest implements GraphQLOperationRequest {
         return new ProductsByIdsQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/from-introspection-result/ProductsQueryRequest.java.txt
+++ b/src/test/resources/expected-classes/from-introspection-result/ProductsQueryRequest.java.txt
@@ -62,6 +62,10 @@ public class ProductsQueryRequest implements GraphQLOperationRequest {
         return new ProductsQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/immutable/Event.java.txt
+++ b/src/test/resources/expected-classes/immutable/Event.java.txt
@@ -73,6 +73,10 @@ public class Event implements java.io.Serializable {
         return new Event.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String id;

--- a/src/test/resources/expected-classes/interfaces/Bar1.java.txt
+++ b/src/test/resources/expected-classes/interfaces/Bar1.java.txt
@@ -32,6 +32,10 @@ public class Bar1 implements java.io.Serializable, Bar {
         return new Bar1.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String id;

--- a/src/test/resources/expected-classes/interfaces/Foo1.java.txt
+++ b/src/test/resources/expected-classes/interfaces/Foo1.java.txt
@@ -41,6 +41,10 @@ public class Foo1 implements java.io.Serializable, Foo {
         return new Foo1.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String id;

--- a/src/test/resources/expected-classes/jackson-resolver-union/UnionMemberA.java.txt
+++ b/src/test/resources/expected-classes/jackson-resolver-union/UnionMemberA.java.txt
@@ -31,6 +31,10 @@ public class UnionMemberA implements java.io.Serializable, UnionToResolve {
         return new UnionMemberA.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Integer someField;

--- a/src/test/resources/expected-classes/jackson-resolver-union/UnionMemberB.java.txt
+++ b/src/test/resources/expected-classes/jackson-resolver-union/UnionMemberB.java.txt
@@ -31,6 +31,10 @@ public class UnionMemberB implements java.io.Serializable, UnionToResolve {
         return new UnionMemberB.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String someField;

--- a/src/test/resources/expected-classes/jackson-resolver-union/without-model-package/MyUnionMemberASuffix.java.txt
+++ b/src/test/resources/expected-classes/jackson-resolver-union/without-model-package/MyUnionMemberASuffix.java.txt
@@ -28,6 +28,10 @@ public class MyUnionMemberASuffix implements java.io.Serializable, MyUnionToReso
         return new MyUnionMemberASuffix.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Integer someField;

--- a/src/test/resources/expected-classes/jackson-resolver-union/without-model-package/MyUnionMemberBSuffix.java.txt
+++ b/src/test/resources/expected-classes/jackson-resolver-union/without-model-package/MyUnionMemberBSuffix.java.txt
@@ -28,6 +28,10 @@ public class MyUnionMemberBSuffix implements java.io.Serializable, MyUnionToReso
         return new MyUnionMemberBSuffix.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String someField;

--- a/src/test/resources/expected-classes/no-args-constructor/Event_noargsconstr_builder.java.txt
+++ b/src/test/resources/expected-classes/no-args-constructor/Event_noargsconstr_builder.java.txt
@@ -87,6 +87,10 @@ public class Event implements java.io.Serializable {
         return new Event.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String id;

--- a/src/test/resources/expected-classes/optional/TypeWithMandatoryField.java.txt
+++ b/src/test/resources/expected-classes/optional/TypeWithMandatoryField.java.txt
@@ -53,6 +53,10 @@ public class TypeWithMandatoryField implements java.io.Serializable, InterfaceWi
         return new TypeWithMandatoryField.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private int test;

--- a/src/test/resources/expected-classes/primitives/Commit_withoutPrimitives.java.txt
+++ b/src/test/resources/expected-classes/primitives/Commit_withoutPrimitives.java.txt
@@ -394,6 +394,10 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         return new Commit.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String abbreviatedOid;

--- a/src/test/resources/expected-classes/public-fields/Event_publicfields.java.txt
+++ b/src/test/resources/expected-classes/public-fields/Event_publicfields.java.txt
@@ -72,6 +72,10 @@ public class Event implements java.io.Serializable {
         return new Event.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String id;

--- a/src/test/resources/expected-classes/public-fields/Event_publicfields_builder_noargsconstr.java.txt
+++ b/src/test/resources/expected-classes/public-fields/Event_publicfields_builder_noargsconstr.java.txt
@@ -62,6 +62,10 @@ public class Event implements java.io.Serializable {
         return new Event.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String id;

--- a/src/test/resources/expected-classes/relay/Organization.java.txt
+++ b/src/test/resources/expected-classes/relay/Organization.java.txt
@@ -30,6 +30,10 @@ public class Organization implements java.io.Serializable {
         return new Organization.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String id;

--- a/src/test/resources/expected-classes/relay/User.java.txt
+++ b/src/test/resources/expected-classes/relay/User.java.txt
@@ -39,6 +39,10 @@ public class User implements java.io.Serializable {
         return new User.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String id;

--- a/src/test/resources/expected-classes/request/AcceptTopicSuggestionInput.java.txt
+++ b/src/test/resources/expected-classes/request/AcceptTopicSuggestionInput.java.txt
@@ -86,6 +86,10 @@ public class AcceptTopicSuggestionInput implements java.io.Serializable {
         return new AcceptTopicSuggestionInput.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String clientMutationId;

--- a/src/test/resources/expected-classes/request/Event_useObjectMapperForRequestSerialization.java.txt
+++ b/src/test/resources/expected-classes/request/Event_useObjectMapperForRequestSerialization.java.txt
@@ -152,6 +152,10 @@ public class Event implements java.io.Serializable {
         return new Event.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String id;

--- a/src/test/resources/expected-classes/request/EventsByCategoryAndStatusQueryRequest.java.txt
+++ b/src/test/resources/expected-classes/request/EventsByCategoryAndStatusQueryRequest.java.txt
@@ -91,6 +91,10 @@ public class EventsByCategoryAndStatusQueryRequest implements GraphQLOperationRe
         return new EventsByCategoryAndStatusQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/request/EventsByCategoryAndStatusQueryRequest_withApiImport.java.txt
+++ b/src/test/resources/expected-classes/request/EventsByCategoryAndStatusQueryRequest_withApiImport.java.txt
@@ -91,6 +91,10 @@ public class EventsByCategoryAndStatusQueryRequest implements GraphQLOperationRe
         return new EventsByCategoryAndStatusQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/request/EventsByCategoryAndStatusQueryRequest_withModelSuffix.java.txt
+++ b/src/test/resources/expected-classes/request/EventsByCategoryAndStatusQueryRequest_withModelSuffix.java.txt
@@ -91,6 +91,10 @@ public class EventsByCategoryAndStatusQueryRequest implements GraphQLOperationRe
         return new EventsByCategoryAndStatusQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/request/EventsByIdsQueryRequest.java.txt
+++ b/src/test/resources/expected-classes/request/EventsByIdsQueryRequest.java.txt
@@ -87,6 +87,10 @@ public class EventsByIdsQueryRequest implements GraphQLOperationRequest {
         return new EventsByIdsQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/request/ProductsByCategoryIdAndStatusQueryRequest.java.txt
+++ b/src/test/resources/expected-classes/request/ProductsByCategoryIdAndStatusQueryRequest.java.txt
@@ -88,6 +88,10 @@ public class ProductsByCategoryIdAndStatusQueryRequest implements GraphQLOperati
         return new ProductsByCategoryIdAndStatusQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/request/ProductsByIdsQueryRequest.java.txt
+++ b/src/test/resources/expected-classes/request/ProductsByIdsQueryRequest.java.txt
@@ -84,6 +84,10 @@ public class ProductsByIdsQueryRequest implements GraphQLOperationRequest {
         return new ProductsByIdsQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/request/QueryINeedQueryRequest_custom_serializer.java.txt
+++ b/src/test/resources/expected-classes/request/QueryINeedQueryRequest_custom_serializer.java.txt
@@ -85,6 +85,10 @@ public class QueryINeedQueryRequest implements GraphQLOperationRequest {
         return new QueryINeedQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/request/UpdateRepositoryMutationRequest.java.txt
+++ b/src/test/resources/expected-classes/request/UpdateRepositoryMutationRequest.java.txt
@@ -84,6 +84,10 @@ public class UpdateRepositoryMutationRequest implements GraphQLOperationRequest 
         return new UpdateRepositoryMutationRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/request/VersionQueryRequest.java.txt
+++ b/src/test/resources/expected-classes/request/VersionQueryRequest.java.txt
@@ -83,6 +83,10 @@ public class VersionQueryRequest implements GraphQLOperationRequest {
         return new VersionQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/resolvers/B.java.txt
+++ b/src/test/resources/expected-classes/resolvers/B.java.txt
@@ -41,6 +41,10 @@ public class B implements java.io.Serializable, A {
         return new B.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String foo;

--- a/src/test/resources/expected-classes/resolvers/CommentDeletedEvent.java.txt
+++ b/src/test/resources/expected-classes/resolvers/CommentDeletedEvent.java.txt
@@ -32,6 +32,10 @@ public class CommentDeletedEvent implements java.io.Serializable, IssueTimelineI
         return new CommentDeletedEvent.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String id;

--- a/src/test/resources/expected-classes/resolvers/Commit_noParametrizedFields.java.txt
+++ b/src/test/resources/expected-classes/resolvers/Commit_noParametrizedFields.java.txt
@@ -330,6 +330,10 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         return new Commit.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String abbreviatedOid;

--- a/src/test/resources/expected-classes/resolvers/Event.java.txt
+++ b/src/test/resources/expected-classes/resolvers/Event.java.txt
@@ -88,6 +88,10 @@ public class Event implements java.io.Serializable {
         return new Event.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String id;

--- a/src/test/resources/expected-classes/resolvers/EventProperty.java.txt
+++ b/src/test/resources/expected-classes/resolvers/EventProperty.java.txt
@@ -42,6 +42,10 @@ public class EventProperty implements java.io.Serializable {
         return new EventProperty.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Double floatVal;

--- a/src/test/resources/expected-classes/restricted-words/CaseQueryRequest.java.txt
+++ b/src/test/resources/expected-classes/restricted-words/CaseQueryRequest.java.txt
@@ -84,6 +84,10 @@ public class CaseQueryRequest implements GraphQLOperationRequest {
         return new CaseQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/restricted-words/NativeQueryRequest.java.txt
+++ b/src/test/resources/expected-classes/restricted-words/NativeQueryRequest.java.txt
@@ -80,6 +80,10 @@ public class NativeQueryRequest implements GraphQLOperationRequest {
         return new NativeQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/restricted-words/PrivateQueryRequest.java.txt
+++ b/src/test/resources/expected-classes/restricted-words/PrivateQueryRequest.java.txt
@@ -92,6 +92,10 @@ public class PrivateQueryRequest implements GraphQLOperationRequest {
         return new PrivateQueryRequest.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String $alias;

--- a/src/test/resources/expected-classes/restricted-words/Query.java.txt
+++ b/src/test/resources/expected-classes/restricted-words/Query.java.txt
@@ -58,6 +58,10 @@ public class Query implements java.io.Serializable {
         return new Query.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String Native;

--- a/src/test/resources/expected-classes/restricted-words/Synchronized.java.txt
+++ b/src/test/resources/expected-classes/restricted-words/Synchronized.java.txt
@@ -84,6 +84,10 @@ public class Synchronized implements java.io.Serializable {
         return new Synchronized.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String Void;

--- a/src/test/resources/expected-classes/types-as-interfaces-extends-interface/Profile.java.txt
+++ b/src/test/resources/expected-classes/types-as-interfaces-extends-interface/Profile.java.txt
@@ -42,6 +42,10 @@ public class Profile implements java.io.Serializable {
         return new Profile.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String firstName;

--- a/src/test/resources/expected-classes/unknown-fields/InputWithDefaults.java.txt
+++ b/src/test/resources/expected-classes/unknown-fields/InputWithDefaults.java.txt
@@ -137,6 +137,10 @@ public class InputWithDefaults implements java.io.Serializable {
         return new InputWithDefaults.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private Double floatVal = 1.23;

--- a/src/test/resources/expected-classes/unknown-fields/SomeObject.java.txt
+++ b/src/test/resources/expected-classes/unknown-fields/SomeObject.java.txt
@@ -43,6 +43,10 @@ public class SomeObject implements java.io.Serializable {
         return new SomeObject.Builder();
     }
 
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
     public static class Builder {
 
         private String name;


### PR DESCRIPTION
---

### Description

Added `@Generated` annotation to builder class.

This is useful when for instance you want to exclude some generated classes from code coverage.

---

Changes were made to:
- [x] Codegen library - Java
- [ ] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
