### PR TITLE
drop test task when release

### DIFF
--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/build.sbt
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/build.sbt
@@ -22,7 +22,6 @@ lazy val `graphql-codegen-sbt-plugin` = Project(id = "graphql-codegen-sbt-plugin
       checkSnapshotDependencies,
       inquireVersions,
       runClean,
-      releaseStepCommandAndRemaining("^ scripted"),
       setReleaseVersion,
       commitReleaseVersion,
       tagRelease,


### PR DESCRIPTION
As CI has already been tested, it is removed here to expedite release