### PR TITLE
specify javadoc encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ codeCoverageReport.dependsOn test
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"
 
+javadoc {
+    options.encoding = "UTF-8"
+}
+
 java {
     withJavadocJar()
     withSourcesJar()

--- a/build.gradle
+++ b/build.gradle
@@ -65,10 +65,7 @@ codeCoverageReport.dependsOn test
 
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"
-
-javadoc {
-    options.encoding = "UTF-8"
-}
+javadoc.options.encoding = "UTF-8"
 
 java {
     withJavadocJar()


### PR DESCRIPTION
---

### Description
I did puglishToMavenLocal and got an error in the javadoc section.
I am in a Japanese environment.
![image](https://user-images.githubusercontent.com/9250063/235448970-3edd3e16-14fc-43f9-959b-404e42d79dee.png)

It seems to be set at compile time, so I set it in javadoc as well.
https://github.com/kobylynskyi/graphql-java-codegen/blob/a300a409c98e5ee491b10fc135194a0461264a49/build.gradle#L66-L67

---

Changes were made to:
- [ ] Codegen library - Java
- [ ] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
