### PR TITLE
support placeholder at apiReturnListType and apiReturnType

### DIFF
--- a/src/main/java/com/kobylynskyi/graphql/codegen/java/JavaGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/java/JavaGraphQLTypeMapper.java
@@ -73,7 +73,9 @@ public class JavaGraphQLTypeMapper extends GraphQLTypeMapper {
                 Matcher matcher = JAVA_UTIL_LIST_ELEMENT_REGEX.matcher(computedTypeName);
                 matcher.find();
                 String listElement = matcher.group(1);
-                return mappingContext.getApiReturnListType().replace(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER, listElement);
+                return mappingContext.getApiReturnListType().replace(
+                        MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER,
+                        listElement);
             } else {
                 return computedTypeName.replace(JAVA_UTIL_LIST, mappingContext.getApiReturnListType());
             }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/java/JavaGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/java/JavaGraphQLTypeMapper.java
@@ -71,11 +71,14 @@ public class JavaGraphQLTypeMapper extends GraphQLTypeMapper {
             // in case it is query/mutation, return type is list and apiReturnListType is set
             if (mappingContext.getApiReturnListType().contains(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER)) {
                 Matcher matcher = JAVA_UTIL_LIST_ELEMENT_REGEX.matcher(computedTypeName);
-                matcher.find();
-                String listElement = matcher.group(1);
-                return mappingContext.getApiReturnListType().replace(
-                        MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER,
-                        listElement);
+                if (matcher.find()) {
+                    String listElement = matcher.group(1);
+                    return mappingContext.getApiReturnListType().replace(
+                            MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER,
+                            listElement);
+                } else {
+                    throw new IllegalStateException();
+                }
             } else {
                 return computedTypeName.replace(JAVA_UTIL_LIST, mappingContext.getApiReturnListType());
             }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/java/JavaGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/java/JavaGraphQLTypeMapper.java
@@ -11,6 +11,8 @@ import com.kobylynskyi.graphql.codegen.utils.Utils;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
 
@@ -20,6 +22,7 @@ import static java.util.Arrays.asList;
 public class JavaGraphQLTypeMapper extends GraphQLTypeMapper {
 
     public static final String JAVA_UTIL_LIST = "java.util.List";
+    public static final Pattern JAVA_UTIL_LIST_ELEMENT_REGEX = Pattern.compile("java\\.util\\.List<(.+)>");
     private static final String JAVA_UTIL_OPTIONAL = "java.util.Optional";
     private static final Set<String> JAVA_PRIMITIVE_TYPES = new HashSet<>(asList(
             "byte", "short", "int", "long", "float", "double", "char", "boolean"));
@@ -66,7 +69,14 @@ public class JavaGraphQLTypeMapper extends GraphQLTypeMapper {
         if (computedTypeName.startsWith(JAVA_UTIL_LIST) &&
                 Utils.isNotBlank(mappingContext.getApiReturnListType())) {
             // in case it is query/mutation, return type is list and apiReturnListType is set
-            return computedTypeName.replace(JAVA_UTIL_LIST, mappingContext.getApiReturnListType());
+            if (mappingContext.getApiReturnListType().contains(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER)) {
+                Matcher matcher = JAVA_UTIL_LIST_ELEMENT_REGEX.matcher(computedTypeName);
+                matcher.find();
+                String listElement = matcher.group(1);
+                return mappingContext.getApiReturnListType().replace(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER, listElement);
+            } else {
+                return computedTypeName.replace(JAVA_UTIL_LIST, mappingContext.getApiReturnListType());
+            }
         }
         if (Utils.isNotBlank(mappingContext.getApiReturnType())) {
             // in case it is query/mutation and apiReturnType is set

--- a/src/main/java/com/kobylynskyi/graphql/codegen/java/JavaGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/java/JavaGraphQLTypeMapper.java
@@ -2,6 +2,7 @@ package com.kobylynskyi.graphql.codegen.java;
 
 import com.kobylynskyi.graphql.codegen.mapper.DataModelMapper;
 import com.kobylynskyi.graphql.codegen.mapper.GraphQLTypeMapper;
+import com.kobylynskyi.graphql.codegen.model.MappingConfigConstants;
 import com.kobylynskyi.graphql.codegen.model.MappingContext;
 import com.kobylynskyi.graphql.codegen.model.NamedDefinition;
 import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLOperation;
@@ -69,7 +70,12 @@ public class JavaGraphQLTypeMapper extends GraphQLTypeMapper {
         }
         if (Utils.isNotBlank(mappingContext.getApiReturnType())) {
             // in case it is query/mutation and apiReturnType is set
-            return getGenericsString(mappingContext, mappingContext.getApiReturnType(), computedTypeName);
+            if (mappingContext.getApiReturnType().contains(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER)) {
+                return mappingContext.getApiReturnType()
+                        .replace(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER, computedTypeName);
+            } else {
+                return getGenericsString(mappingContext, mappingContext.getApiReturnType(), computedTypeName);
+            }
         }
         return getTypeConsideringPrimitive(mappingContext, namedDefinition, computedTypeName);
     }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
@@ -10,6 +10,8 @@ import com.kobylynskyi.graphql.codegen.utils.Utils;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
 
@@ -22,6 +24,7 @@ import static java.util.Arrays.asList;
 public class KotlinGraphQLTypeMapper extends GraphQLTypeMapper {
 
     private static final String KOTLIN_UTIL_LIST = "List";
+    public static final Pattern KOTLIN_UTIL_LIST_ELEMENT_REGEX = Pattern.compile("List<(.+?)>");
     private static final String KOTLIN_UTIL_NULLABLE = "?";
     // Char Boolean are not primitive type, but non null equivalent jvm primitive types.
     private static final Set<String> KOTLIN_PRIMITIVE_TYPES = new HashSet<>(
@@ -93,7 +96,15 @@ public class KotlinGraphQLTypeMapper extends GraphQLTypeMapper {
         if (computedTypeName.startsWith(KOTLIN_UTIL_LIST) &&
                 Utils.isNotBlank(mappingContext.getApiReturnListType())) {
             // in case it is query/mutation, return type is list and apiReturnListType is set
-            return computedTypeName.replace(KOTLIN_UTIL_LIST, mappingContext.getApiReturnListType());
+            if (mappingContext.getApiReturnListType().contains(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER)) {
+                System.out.println("computedTypeName = " + computedTypeName);
+                Matcher matcher = KOTLIN_UTIL_LIST_ELEMENT_REGEX.matcher(computedTypeName);
+                matcher.find();
+                String listElement = matcher.group(1);
+                return mappingContext.getApiReturnListType().replace(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER, listElement);
+            } else {
+                return computedTypeName.replace(KOTLIN_UTIL_LIST, mappingContext.getApiReturnListType());
+            }
         }
         if (Utils.isNotBlank(mappingContext.getApiReturnType())) {
             // in case it is query/mutation and apiReturnType is set

--- a/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
@@ -2,6 +2,7 @@ package com.kobylynskyi.graphql.codegen.kotlin;
 
 import com.kobylynskyi.graphql.codegen.mapper.DataModelMapper;
 import com.kobylynskyi.graphql.codegen.mapper.GraphQLTypeMapper;
+import com.kobylynskyi.graphql.codegen.model.MappingConfigConstants;
 import com.kobylynskyi.graphql.codegen.model.MappingContext;
 import com.kobylynskyi.graphql.codegen.model.NamedDefinition;
 import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLOperation;
@@ -96,7 +97,12 @@ public class KotlinGraphQLTypeMapper extends GraphQLTypeMapper {
         }
         if (Utils.isNotBlank(mappingContext.getApiReturnType())) {
             // in case it is query/mutation and apiReturnType is set
-            return getGenericsString(mappingContext, mappingContext.getApiReturnType(), computedTypeName);
+            if (mappingContext.getApiReturnType().contains(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER)) {
+                return mappingContext.getApiReturnType()
+                        .replace(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER, computedTypeName);
+            } else {
+                return getGenericsString(mappingContext, mappingContext.getApiReturnType(), computedTypeName);
+            }
         }
         return getTypeConsideringPrimitive(mappingContext, namedDefinition, computedTypeName);
     }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
@@ -101,7 +101,9 @@ public class KotlinGraphQLTypeMapper extends GraphQLTypeMapper {
                 Matcher matcher = KOTLIN_UTIL_LIST_ELEMENT_REGEX.matcher(computedTypeName);
                 matcher.find();
                 String listElement = matcher.group(1);
-                return mappingContext.getApiReturnListType().replace(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER, listElement);
+                return mappingContext.getApiReturnListType().replace(
+                        MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER,
+                        listElement);
             } else {
                 return computedTypeName.replace(KOTLIN_UTIL_LIST, mappingContext.getApiReturnListType());
             }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
@@ -24,7 +24,7 @@ import static java.util.Arrays.asList;
 public class KotlinGraphQLTypeMapper extends GraphQLTypeMapper {
 
     private static final String KOTLIN_UTIL_LIST = "List";
-    public static final Pattern KOTLIN_UTIL_LIST_ELEMENT_REGEX = Pattern.compile("List<(.+?)>");
+    public static final Pattern KOTLIN_UTIL_LIST_ELEMENT_REGEX = Pattern.compile("List<(.+)>");
     private static final String KOTLIN_UTIL_NULLABLE = "?";
     // Char Boolean are not primitive type, but non null equivalent jvm primitive types.
     private static final Set<String> KOTLIN_PRIMITIVE_TYPES = new HashSet<>(

--- a/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
@@ -97,7 +97,6 @@ public class KotlinGraphQLTypeMapper extends GraphQLTypeMapper {
                 Utils.isNotBlank(mappingContext.getApiReturnListType())) {
             // in case it is query/mutation, return type is list and apiReturnListType is set
             if (mappingContext.getApiReturnListType().contains(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER)) {
-                System.out.println("computedTypeName = " + computedTypeName);
                 Matcher matcher = KOTLIN_UTIL_LIST_ELEMENT_REGEX.matcher(computedTypeName);
                 matcher.find();
                 String listElement = matcher.group(1);

--- a/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
@@ -100,15 +100,18 @@ public class KotlinGraphQLTypeMapper extends GraphQLTypeMapper {
                 boolean isNullable = computedTypeName.endsWith(KOTLIN_UTIL_NULLABLE);
 
                 Matcher matcher = KOTLIN_UTIL_LIST_ELEMENT_REGEX.matcher(computedTypeName);
-                matcher.find();
-                String listElement = matcher.group(1);
-                computedTypeName = mappingContext.getApiReturnListType()
-                        .replace(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER, listElement);
+                if (matcher.find()) {
+                    String listElement = matcher.group(1);
+                    computedTypeName = mappingContext.getApiReturnListType()
+                            .replace(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER, listElement);
 
-                if (isNullable) {
-                    return computedTypeName + "?";
+                    if (isNullable) {
+                        return computedTypeName + "?";
+                    } else {
+                        return computedTypeName;
+                    }
                 } else {
-                    return computedTypeName;
+                    throw new IllegalStateException();
                 }
             } else {
                 return computedTypeName.replace(KOTLIN_UTIL_LIST, mappingContext.getApiReturnListType());

--- a/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/kotlin/KotlinGraphQLTypeMapper.java
@@ -97,12 +97,19 @@ public class KotlinGraphQLTypeMapper extends GraphQLTypeMapper {
                 Utils.isNotBlank(mappingContext.getApiReturnListType())) {
             // in case it is query/mutation, return type is list and apiReturnListType is set
             if (mappingContext.getApiReturnListType().contains(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER)) {
+                boolean isNullable = computedTypeName.endsWith(KOTLIN_UTIL_NULLABLE);
+
                 Matcher matcher = KOTLIN_UTIL_LIST_ELEMENT_REGEX.matcher(computedTypeName);
                 matcher.find();
                 String listElement = matcher.group(1);
-                return mappingContext.getApiReturnListType().replace(
-                        MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER,
-                        listElement);
+                computedTypeName = mappingContext.getApiReturnListType()
+                        .replace(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER, listElement);
+
+                if (isNullable) {
+                    return computedTypeName + "?";
+                } else {
+                    return computedTypeName;
+                }
             } else {
                 return computedTypeName.replace(KOTLIN_UTIL_LIST, mappingContext.getApiReturnListType());
             }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/model/MappingConfigConstants.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/model/MappingConfigConstants.java
@@ -9,6 +9,7 @@ public class MappingConfigConstants {
     public static final String DEFAULT_VALIDATION_ANNOTATION = "javax.validation.constraints.NotNull";
     public static final String PARENT_INTERFACE_TYPE_PLACEHOLDER = "{{TYPE}}";
     public static final String TYPE_NAME_PLACEHOLDER = "{{TYPE_NAME}}";
+    public static final String API_RETURN_NAME_PLACEHOLDER = "{{TYPE}}";
 
     public static final boolean DEFAULT_GENERATE_APIS = true;
     public static final String DEFAULT_GENERATE_APIS_STRING = "true";

--- a/src/main/java/com/kobylynskyi/graphql/codegen/scala/ScalaGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/scala/ScalaGraphQLTypeMapper.java
@@ -1,6 +1,7 @@
 package com.kobylynskyi.graphql.codegen.scala;
 
 import com.kobylynskyi.graphql.codegen.mapper.GraphQLTypeMapper;
+import com.kobylynskyi.graphql.codegen.model.MappingConfigConstants;
 import com.kobylynskyi.graphql.codegen.model.MappingContext;
 import com.kobylynskyi.graphql.codegen.model.NamedDefinition;
 import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLOperation;
@@ -76,7 +77,12 @@ public class ScalaGraphQLTypeMapper extends GraphQLTypeMapper {
         }
         if (Utils.isNotBlank(mappingContext.getApiReturnType())) {
             // in case it is query/mutation and apiReturnType is set
-            return getGenericsString(mappingContext, mappingContext.getApiReturnType(), computedTypeName);
+            if (mappingContext.getApiReturnType().contains(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER)) {
+                return mappingContext.getApiReturnType()
+                        .replace(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER, computedTypeName);
+            } else {
+                return getGenericsString(mappingContext, mappingContext.getApiReturnType(), computedTypeName);
+            }
         }
         return getTypeConsideringPrimitive(mappingContext, namedDefinition, computedTypeName);
     }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/scala/ScalaGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/scala/ScalaGraphQLTypeMapper.java
@@ -81,7 +81,9 @@ public class ScalaGraphQLTypeMapper extends GraphQLTypeMapper {
                 Matcher matcher = SCALA_UTIL_LIST_ELEMENT_REGEX.matcher(computedTypeName);
                 matcher.find();
                 String listElement = matcher.group(1);
-                return mappingContext.getApiReturnListType().replace(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER, listElement);
+                return mappingContext.getApiReturnListType().replace(
+                        MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER,
+                        listElement);
             } else {
                 return computedTypeName.replace(SCALA_UTIL_LIST, mappingContext.getApiReturnListType());
             }

--- a/src/main/java/com/kobylynskyi/graphql/codegen/scala/ScalaGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/scala/ScalaGraphQLTypeMapper.java
@@ -77,7 +77,6 @@ public class ScalaGraphQLTypeMapper extends GraphQLTypeMapper {
                 Utils.isNotBlank(mappingContext.getApiReturnListType())) {
             // in case it is query/mutation, return type is list and apiReturnListType is set
             if (mappingContext.getApiReturnListType().contains(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER)) {
-                System.out.println("computedTypeName = " + computedTypeName);
                 Matcher matcher = SCALA_UTIL_LIST_ELEMENT_REGEX.matcher(computedTypeName);
                 matcher.find();
                 String listElement = matcher.group(1);

--- a/src/main/java/com/kobylynskyi/graphql/codegen/scala/ScalaGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/scala/ScalaGraphQLTypeMapper.java
@@ -9,6 +9,8 @@ import com.kobylynskyi.graphql.codegen.utils.Utils;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.kobylynskyi.graphql.codegen.java.JavaGraphQLTypeMapper.JAVA_UTIL_LIST;
 import static java.util.Arrays.asList;
@@ -19,6 +21,7 @@ import static java.util.Arrays.asList;
 public class ScalaGraphQLTypeMapper extends GraphQLTypeMapper {
 
     private static final String SCALA_UTIL_LIST = "scala.Seq";
+    private static final Pattern SCALA_UTIL_LIST_ELEMENT_REGEX = Pattern.compile("scala\\.Seq\\[(.+)]");
     private static final String SCALA_UTIL_OPTIONAL = "scala.Option";
     private static final Set<String> SCALA_PRIMITIVE_TYPES = new HashSet<>(asList(
             "Byte", "Short", "Int", "Long", "Float", "Double", "Char", "Boolean"));
@@ -73,7 +76,15 @@ public class ScalaGraphQLTypeMapper extends GraphQLTypeMapper {
         if (computedTypeName.startsWith(SCALA_UTIL_LIST) &&
                 Utils.isNotBlank(mappingContext.getApiReturnListType())) {
             // in case it is query/mutation, return type is list and apiReturnListType is set
-            return computedTypeName.replace(SCALA_UTIL_LIST, mappingContext.getApiReturnListType());
+            if (mappingContext.getApiReturnListType().contains(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER)) {
+                System.out.println("computedTypeName = " + computedTypeName);
+                Matcher matcher = SCALA_UTIL_LIST_ELEMENT_REGEX.matcher(computedTypeName);
+                matcher.find();
+                String listElement = matcher.group(1);
+                return mappingContext.getApiReturnListType().replace(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER, listElement);
+            } else {
+                return computedTypeName.replace(SCALA_UTIL_LIST, mappingContext.getApiReturnListType());
+            }
         }
         if (Utils.isNotBlank(mappingContext.getApiReturnType())) {
             // in case it is query/mutation and apiReturnType is set

--- a/src/main/java/com/kobylynskyi/graphql/codegen/scala/ScalaGraphQLTypeMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/scala/ScalaGraphQLTypeMapper.java
@@ -78,11 +78,14 @@ public class ScalaGraphQLTypeMapper extends GraphQLTypeMapper {
             // in case it is query/mutation, return type is list and apiReturnListType is set
             if (mappingContext.getApiReturnListType().contains(MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER)) {
                 Matcher matcher = SCALA_UTIL_LIST_ELEMENT_REGEX.matcher(computedTypeName);
-                matcher.find();
-                String listElement = matcher.group(1);
-                return mappingContext.getApiReturnListType().replace(
-                        MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER,
-                        listElement);
+                if (matcher.find()) {
+                    String listElement = matcher.group(1);
+                    return mappingContext.getApiReturnListType().replace(
+                            MappingConfigConstants.API_RETURN_NAME_PLACEHOLDER,
+                            listElement);
+                } else {
+                    throw new IllegalStateException();
+                }
             } else {
                 return computedTypeName.replace(SCALA_UTIL_LIST, mappingContext.getApiReturnListType());
             }

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenApiReturnTypeTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenApiReturnTypeTest.java
@@ -1,0 +1,74 @@
+package com.kobylynskyi.graphql.codegen;
+
+import com.kobylynskyi.graphql.codegen.java.JavaGraphQLCodegen;
+import com.kobylynskyi.graphql.codegen.model.GeneratedLanguage;
+import com.kobylynskyi.graphql.codegen.model.MappingConfig;
+import com.kobylynskyi.graphql.codegen.scala.ScalaGraphQLCodegen;
+import com.kobylynskyi.graphql.codegen.utils.Utils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+
+import static com.kobylynskyi.graphql.codegen.TestUtils.assertFileContainsElements;
+import static java.util.Collections.singletonList;
+
+class GraphQLCodegenApiReturnTypeTest {
+
+    private final File outputBuildDir = new File("build/generated");
+    private final File outputJavaClassesDir = new File("build/generated/com/kobylynskyi/graphql/test1");
+
+    private MappingConfig mappingConfig;
+
+    @BeforeEach
+    void init() {
+        mappingConfig = new MappingConfig();
+        mappingConfig.setPackageName("com.kobylynskyi.graphql.test1");
+        mappingConfig.setGeneratedLanguage(GeneratedLanguage.JAVA);
+    }
+
+    @AfterEach
+    void cleanup() {
+        Utils.deleteDir(outputBuildDir);
+    }
+
+    @Test
+    void generate_ApiReturnType_WithPlaceHolder() throws Exception {
+        mappingConfig.setApiReturnType("java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<{{TYPE}}>>");
+
+        generate("src/test/resources/schemas/test.graphqls");
+
+        File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
+
+        assertFileContainsElements(files, "EventPropertyResolver.java",
+                "java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<java.util.List<EventProperty>>> child(EventProperty eventProperty, Integer first, Integer last) throws Exception;");
+
+        assertFileContainsElements(files, "EventPropertyResolver.java",
+                "java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<Event>> parent(EventProperty eventProperty, EventStatus withStatus, String createdAfter) throws Exception;");
+    }
+
+    @Test
+    void generate_ApiReturnType_And_ApiReturnListType_WithPlaceHolder() throws Exception {
+        mappingConfig.setApiReturnType("java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<{{TYPE}}>>");
+        mappingConfig.setApiReturnListType("reactor.core.publisher.Mono<graphql.execution.DataFetcherResult<{{TYPE}}>>");
+
+        generate("src/test/resources/schemas/test.graphqls");
+
+        File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
+
+        assertFileContainsElements(files, "EventPropertyResolver.java",
+                "reactor.core.publisher.Mono<graphql.execution.DataFetcherResult<EventProperty>> child(EventProperty eventProperty, Integer first, Integer last) throws Exception;");
+
+        assertFileContainsElements(files, "EventPropertyResolver.java",
+                "java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<Event>> parent(EventProperty eventProperty, EventStatus withStatus, String createdAfter) throws Exception;");
+    }
+
+    private void generate(String path) throws IOException {
+        new JavaGraphQLCodegen(singletonList(path), outputBuildDir, mappingConfig,
+                TestUtils.getStaticGeneratedInfo(mappingConfig)).generate();
+    }
+
+}

--- a/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenApiReturnTypeTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenApiReturnTypeTest.java
@@ -80,7 +80,7 @@ class GraphQLCodegenApiReturnTypeTest {
                 files,
                 "EventPropertyResolver.kt",
                 getChildFunction(
-                        "reactor.core.publisher.Mono<graphql.execution.DataFetcherResult<EventProperty?>>"
+                        "reactor.core.publisher.Mono<graphql.execution.DataFetcherResult<EventProperty?>>?"
                 )
         );
 

--- a/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenApiReturnTypeTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenApiReturnTypeTest.java
@@ -8,11 +8,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 import java.util.Objects;
 
 import static com.kobylynskyi.graphql.codegen.TestUtils.assertFileContainsElements;
-import static java.util.Collections.*;
+import static java.util.Collections.singletonList;
 
 class GraphQLCodegenApiReturnTypeTest {
 
@@ -35,33 +36,71 @@ class GraphQLCodegenApiReturnTypeTest {
 
     @Test
     void generate_ApiReturnType_WithPlaceHolder() throws Exception {
-        mappingConfig.setApiReturnType("java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<{{TYPE}}>>");
+        mappingConfig.setApiReturnType(
+                "java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<{{TYPE}}>>"
+        );
 
         generate("src/test/resources/schemas/test.graphqls");
 
         File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
 
-        assertFileContainsElements(files, "EventPropertyResolver.kt",
-                "fun child(eventProperty: EventProperty, first: Int?, last: Int?): java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<List<EventProperty?>?>>");
+        String requireChildText = getChildFunction(
+                "java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<List<EventProperty?>?>>"
+        );
+        assertFileContainsElements(
+                files,
+                "EventPropertyResolver.kt",
+                requireChildText
+        );
 
-        assertFileContainsElements(files, "EventPropertyResolver.kt",
-                "fun parent(eventProperty: EventProperty, withStatus: EventStatus?, createdAfter: String?): java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<Event?>>");
+        String requireParentText = getParentFunction(
+                "java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<Event?>>"
+        );
+        assertFileContainsElements(
+                files,
+                "EventPropertyResolver.kt",
+                requireParentText
+        );
     }
 
     @Test
     void generate_ApiReturnType_And_ApiReturnListType_WithPlaceHolder() throws Exception {
-        mappingConfig.setApiReturnType("java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<{{TYPE}}>>");
-        mappingConfig.setApiReturnListType("reactor.core.publisher.Mono<graphql.execution.DataFetcherResult<{{TYPE}}>>");
+        mappingConfig.setApiReturnType(
+                "java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<{{TYPE}}>>"
+        );
+        mappingConfig.setApiReturnListType(
+                "reactor.core.publisher.Mono<graphql.execution.DataFetcherResult<{{TYPE}}>>"
+        );
 
         generate("src/test/resources/schemas/test.graphqls");
 
         File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
 
-        assertFileContainsElements(files, "EventPropertyResolver.kt",
-                "fun child(eventProperty: EventProperty, first: Int?, last: Int?): reactor.core.publisher.Mono<graphql.execution.DataFetcherResult<EventProperty?>>");
+        assertFileContainsElements(
+                files,
+                "EventPropertyResolver.kt",
+                getChildFunction(
+                        "reactor.core.publisher.Mono<graphql.execution.DataFetcherResult<EventProperty?>>"
+                )
+        );
 
-        assertFileContainsElements(files, "EventPropertyResolver.kt",
-                "fun parent(eventProperty: EventProperty, withStatus: EventStatus?, createdAfter: String?): java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<Event?>>");
+        assertFileContainsElements(
+                files,
+                "EventPropertyResolver.kt",
+                getParentFunction(
+                        "java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<Event?>>"
+                )
+        );
+    }
+
+    private String getChildFunction(String returnType) {
+        return "fun child(eventProperty: EventProperty, first: Int?, last: Int?)" +
+                ": " + returnType;
+    }
+
+    private String getParentFunction(String returnType) {
+        return "fun parent(eventProperty: EventProperty, withStatus: EventStatus?, createdAfter: String?)" +
+                ": " + returnType;
     }
 
     private void generate(String path) throws IOException {

--- a/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenApiReturnTypeTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/kotlin/GraphQLCodegenApiReturnTypeTest.java
@@ -1,0 +1,72 @@
+package com.kobylynskyi.graphql.codegen.kotlin;
+
+import com.kobylynskyi.graphql.codegen.TestUtils;
+import com.kobylynskyi.graphql.codegen.model.GeneratedLanguage;
+import com.kobylynskyi.graphql.codegen.model.MappingConfig;
+import com.kobylynskyi.graphql.codegen.utils.Utils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.util.Objects;
+
+import static com.kobylynskyi.graphql.codegen.TestUtils.assertFileContainsElements;
+import static java.util.Collections.*;
+
+class GraphQLCodegenApiReturnTypeTest {
+
+    private final File outputBuildDir = new File("build/generated");
+    private final File outputJavaClassesDir = new File("build/generated/com/kobylynskyi/graphql/test1");
+
+    private MappingConfig mappingConfig;
+
+    @BeforeEach
+    void init() {
+        mappingConfig = new MappingConfig();
+        mappingConfig.setPackageName("com.kobylynskyi.graphql.test1");
+        mappingConfig.setGeneratedLanguage(GeneratedLanguage.KOTLIN);
+    }
+
+    @AfterEach
+    void cleanup() {
+        Utils.deleteDir(outputBuildDir);
+    }
+
+    @Test
+    void generate_ApiReturnType_WithPlaceHolder() throws Exception {
+        mappingConfig.setApiReturnType("java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<{{TYPE}}>>");
+
+        generate("src/test/resources/schemas/test.graphqls");
+
+        File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
+
+        assertFileContainsElements(files, "EventPropertyResolver.kt",
+                "fun child(eventProperty: EventProperty, first: Int?, last: Int?): java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<List<EventProperty?>?>>");
+
+        assertFileContainsElements(files, "EventPropertyResolver.kt",
+                "fun parent(eventProperty: EventProperty, withStatus: EventStatus?, createdAfter: String?): java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<Event?>>");
+    }
+
+    @Test
+    void generate_ApiReturnType_And_ApiReturnListType_WithPlaceHolder() throws Exception {
+        mappingConfig.setApiReturnType("java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<{{TYPE}}>>");
+        mappingConfig.setApiReturnListType("reactor.core.publisher.Mono<graphql.execution.DataFetcherResult<{{TYPE}}>>");
+
+        generate("src/test/resources/schemas/test.graphqls");
+
+        File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
+
+        assertFileContainsElements(files, "EventPropertyResolver.kt",
+                "fun child(eventProperty: EventProperty, first: Int?, last: Int?): reactor.core.publisher.Mono<graphql.execution.DataFetcherResult<EventProperty?>>");
+
+        assertFileContainsElements(files, "EventPropertyResolver.kt",
+                "fun parent(eventProperty: EventProperty, withStatus: EventStatus?, createdAfter: String?): java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<Event?>>");
+    }
+
+    private void generate(String path) throws IOException {
+        new KotlinGraphQLCodegen(singletonList(path), outputBuildDir, mappingConfig,
+                TestUtils.getStaticGeneratedInfo(mappingConfig)).generate();
+    }
+
+}

--- a/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenApiReturnTypeTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenApiReturnTypeTest.java
@@ -1,0 +1,74 @@
+package com.kobylynskyi.graphql.codegen.scala;
+
+import com.kobylynskyi.graphql.codegen.TestUtils;
+import com.kobylynskyi.graphql.codegen.kotlin.KotlinGraphQLCodegen;
+import com.kobylynskyi.graphql.codegen.model.GeneratedLanguage;
+import com.kobylynskyi.graphql.codegen.model.MappingConfig;
+import com.kobylynskyi.graphql.codegen.utils.Utils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+
+import static com.kobylynskyi.graphql.codegen.TestUtils.assertFileContainsElements;
+import static java.util.Collections.singletonList;
+
+class GraphQLCodegenApiReturnTypeTest {
+
+    private final File outputBuildDir = new File("build/generated");
+    private final File outputJavaClassesDir = new File("build/generated/com/kobylynskyi/graphql/test1");
+
+    private MappingConfig mappingConfig;
+
+    @BeforeEach
+    void init() {
+        mappingConfig = new MappingConfig();
+        mappingConfig.setPackageName("com.kobylynskyi.graphql.test1");
+        mappingConfig.setGeneratedLanguage(GeneratedLanguage.SCALA);
+    }
+
+    @AfterEach
+    void cleanup() {
+        Utils.deleteDir(outputBuildDir);
+    }
+
+    @Test
+    void generate_ApiReturnType_WithPlaceHolder() throws Exception {
+        mappingConfig.setApiReturnType("java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[{{TYPE}}]]");
+
+        generate("src/test/resources/schemas/test.graphqls");
+
+        File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
+
+        assertFileContainsElements(files, "EventPropertyResolver.scala",
+                "def child(eventProperty: EventProperty, first: scala.Option[Int], last: scala.Option[Int]): java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[scala.Seq[EventProperty]]]");
+
+        assertFileContainsElements(files, "EventPropertyResolver.scala",
+                "def parent(eventProperty: EventProperty, withStatus: EventStatus, createdAfter: String): java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[Event]]");
+    }
+
+    @Test
+    void generate_ApiReturnType_And_ApiReturnListType_WithPlaceHolder() throws Exception {
+        mappingConfig.setApiReturnType("java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[{{TYPE}}]]");
+        mappingConfig.setApiReturnListType("reactor.core.publisher.Mono[graphql.execution.DataFetcherResult[{{TYPE}}]]");
+
+        generate("src/test/resources/schemas/test.graphqls");
+
+        File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
+
+        assertFileContainsElements(files, "EventPropertyResolver.scala",
+                "def child(eventProperty: EventProperty, first: scala.Option[Int], last: scala.Option[Int]): reactor.core.publisher.Mono[graphql.execution.DataFetcherResult[EventProperty]]");
+
+        assertFileContainsElements(files, "EventPropertyResolver.scala",
+                "def parent(eventProperty: EventProperty, withStatus: EventStatus, createdAfter: String): java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[Event]]");
+    }
+
+    private void generate(String path) throws IOException {
+        new ScalaGraphQLCodegen(singletonList(path), outputBuildDir, mappingConfig,
+                TestUtils.getStaticGeneratedInfo(mappingConfig)).generate();
+    }
+
+}

--- a/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenApiReturnTypeTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/scala/GraphQLCodegenApiReturnTypeTest.java
@@ -1,7 +1,6 @@
 package com.kobylynskyi.graphql.codegen.scala;
 
 import com.kobylynskyi.graphql.codegen.TestUtils;
-import com.kobylynskyi.graphql.codegen.kotlin.KotlinGraphQLCodegen;
 import com.kobylynskyi.graphql.codegen.model.GeneratedLanguage;
 import com.kobylynskyi.graphql.codegen.model.MappingConfig;
 import com.kobylynskyi.graphql.codegen.utils.Utils;
@@ -37,33 +36,71 @@ class GraphQLCodegenApiReturnTypeTest {
 
     @Test
     void generate_ApiReturnType_WithPlaceHolder() throws Exception {
-        mappingConfig.setApiReturnType("java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[{{TYPE}}]]");
+        mappingConfig.setApiReturnType(
+                "java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[{{TYPE}}]]"
+        );
 
         generate("src/test/resources/schemas/test.graphqls");
 
         File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
 
-        assertFileContainsElements(files, "EventPropertyResolver.scala",
-                "def child(eventProperty: EventProperty, first: scala.Option[Int], last: scala.Option[Int]): java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[scala.Seq[EventProperty]]]");
+        String childRequireText = getChildFunction(
+                "java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[scala.Seq[EventProperty]]]"
+        );
+        assertFileContainsElements(
+                files,
+                "EventPropertyResolver.scala",
+                childRequireText
+        );
 
-        assertFileContainsElements(files, "EventPropertyResolver.scala",
-                "def parent(eventProperty: EventProperty, withStatus: EventStatus, createdAfter: String): java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[Event]]");
+        String parentRequireText = getParentFunction(
+                "java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[Event]]"
+        );
+        assertFileContainsElements(
+                files,
+                "EventPropertyResolver.scala",
+                parentRequireText
+        );
     }
 
     @Test
     void generate_ApiReturnType_And_ApiReturnListType_WithPlaceHolder() throws Exception {
-        mappingConfig.setApiReturnType("java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[{{TYPE}}]]");
-        mappingConfig.setApiReturnListType("reactor.core.publisher.Mono[graphql.execution.DataFetcherResult[{{TYPE}}]]");
+        mappingConfig.setApiReturnType(
+                "java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[{{TYPE}}]]"
+        );
+        mappingConfig.setApiReturnListType(
+                "reactor.core.publisher.Mono[graphql.execution.DataFetcherResult[{{TYPE}}]]"
+        );
 
         generate("src/test/resources/schemas/test.graphqls");
 
         File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
 
-        assertFileContainsElements(files, "EventPropertyResolver.scala",
-                "def child(eventProperty: EventProperty, first: scala.Option[Int], last: scala.Option[Int]): reactor.core.publisher.Mono[graphql.execution.DataFetcherResult[EventProperty]]");
+        assertFileContainsElements(
+                files,
+                "EventPropertyResolver.scala",
+                getChildFunction(
+                        "reactor.core.publisher.Mono[graphql.execution.DataFetcherResult[EventProperty]]"
+                )
+        );
 
-        assertFileContainsElements(files, "EventPropertyResolver.scala",
-                "def parent(eventProperty: EventProperty, withStatus: EventStatus, createdAfter: String): java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[Event]]");
+        assertFileContainsElements(
+                files,
+                "EventPropertyResolver.scala",
+                getParentFunction(
+                        "java.util.concurrent.CompletionStage[graphql.execution.DataFetcherResult[Event]]"
+                )
+        );
+    }
+
+    private String getChildFunction(String returnType) {
+        return "def child(eventProperty: EventProperty, first: scala.Option[Int], last: scala.Option[Int])" +
+                ": " + returnType;
+    }
+
+    private String getParentFunction(String returnType) {
+        return "def parent(eventProperty: EventProperty, withStatus: EventStatus, createdAfter: String)" +
+                ": " + returnType;
     }
 
     private void generate(String path) throws IOException {


### PR DESCRIPTION
---

### Description

Related to #1167

Added placeholder support for apiReturnListType and apiReturnType.
The following syntax is supported.
```
apiReturnType = "java.util.concurrent.CompletionStage<graphql.execution.DataFetcherResult<{{TYPE}}>>"
```

---

Changes were made to:
- [x] Codegen library - Java
- [x] Codegen library - Kotlin
- [x] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
