### PR TITLE
`customTemplatesRoot` not working for Gradle plugin

### DIFF
--- a/plugins/gradle/graphql-java-codegen-gradle-plugin/src/main/java/io/github/kobylynskyi/graphql/codegen/gradle/GraphQLCodegenGradleTask.java
+++ b/plugins/gradle/graphql-java-codegen-gradle-plugin/src/main/java/io/github/kobylynskyi/graphql/codegen/gradle/GraphQLCodegenGradleTask.java
@@ -19,6 +19,7 @@ import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -342,7 +343,7 @@ public class GraphQLCodegenGradleTask extends DefaultTask implements GraphQLCode
         this.customTypesMapping = customTypesMapping;
     }
 
-    @InputFile
+    @InputDirectory
     @Optional
     @Override
     public File getCustomTemplatesRoot() {


### PR DESCRIPTION
### Description

Resolved bug with `customTemplatesRoot` being validated as a file instead of a directory which will then cause the tasks supplying such an option to fail.

Related to https://github.com/kobylynskyi/graphql-java-codegen/pull/1198

---

Changes were made to:
- [ ] Codegen library - Java
- [ ] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [x] Gradle plugin
- [ ] SBT plugin
