### PR TITLE
Exposed graphQL EnumValue directives to the Freemarker templates

### DIFF
--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/EnumDefinitionToDataModelMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/EnumDefinitionToDataModelMapper.java
@@ -100,7 +100,8 @@ public class EnumDefinitionToDataModelMapper {
                         dataModelMapper.capitalizeIfRestricted(mappingContext, f.getName()),
                         f.getName(),
                         getJavaDoc(f),
-                        DeprecatedDefinitionBuilder.build(mappingContext, f)))
+                        DeprecatedDefinitionBuilder.build(mappingContext, f),
+                        f.getDirectives()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/kobylynskyi/graphql/codegen/model/EnumValueDefinition.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/model/EnumValueDefinition.java
@@ -1,5 +1,6 @@
 package com.kobylynskyi.graphql.codegen.model;
 
+import graphql.language.Directive;
 import java.util.List;
 
 /**
@@ -13,13 +14,16 @@ public class EnumValueDefinition {
     private final String graphqlName;
     private final List<String> javaDoc;
     private final DeprecatedDefinition deprecated;
+    private final List<Directive> directives;
 
     public EnumValueDefinition(String javaName, String graphqlName, List<String> javaDoc,
-                               DeprecatedDefinition deprecated) {
+                               DeprecatedDefinition deprecated, 
+							   List<Directive> directives) {
         this.javaName = javaName;
         this.graphqlName = graphqlName;
         this.javaDoc = javaDoc;
         this.deprecated = deprecated;
+        this.directives = directives;
     }
 
     public String getJavaName() {
@@ -37,4 +41,6 @@ public class EnumValueDefinition {
     public DeprecatedDefinition getDeprecated() {
         return deprecated;
     }
+
+    public List<Directive> getDirectives() { return directives; }
 }


### PR DESCRIPTION
---

### Description

Added support for the Directive attribute for EnumValues to be accessible from Freemarker templates.

---

Changes were made to:
- [x ] Codegen library - Java
- [ ] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
