### PR TITLE
Added Directives to EnumValues

### DIFF
--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/EnumDefinitionToDataModelMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/EnumDefinitionToDataModelMapper.java
@@ -100,7 +100,8 @@ public class EnumDefinitionToDataModelMapper {
                         dataModelMapper.capitalizeIfRestricted(mappingContext, f.getName()),
                         f.getName(),
                         getJavaDoc(f),
-                        DeprecatedDefinitionBuilder.build(mappingContext, f)))
+                        DeprecatedDefinitionBuilder.build(mappingContext, f),
+                        f.getDirectives()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/kobylynskyi/graphql/codegen/model/EnumValueDefinition.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/model/EnumValueDefinition.java
@@ -1,5 +1,6 @@
 package com.kobylynskyi.graphql.codegen.model;
 
+import graphql.language.Directive;
 import java.util.List;
 
 /**
@@ -13,13 +14,16 @@ public class EnumValueDefinition {
     private final String graphqlName;
     private final List<String> javaDoc;
     private final DeprecatedDefinition deprecated;
+    private final List<Directive> directives;
 
     public EnumValueDefinition(String javaName, String graphqlName, List<String> javaDoc,
-                               DeprecatedDefinition deprecated) {
+                               DeprecatedDefinition deprecated, 
+                               List<Directive> directives) {
         this.javaName = javaName;
         this.graphqlName = graphqlName;
         this.javaDoc = javaDoc;
         this.deprecated = deprecated;
+        this.directives = directives;
     }
 
     public String getJavaName() {
@@ -36,5 +40,9 @@ public class EnumValueDefinition {
 
     public DeprecatedDefinition getDeprecated() {
         return deprecated;
+    }
+
+    public List<Directive> getDirectives() {
+        return directives;
     }
 }


### PR DESCRIPTION
---

### Description

Added the Directive attribute from graphql-java to the EnumValueDefinition. FreeMarker templates can now retrieve the directives available on the field.

---

Changes were made to:
- [X] Codegen library - Java
- [ ] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
