### PR TITLE
Patching conflict between generateImmutableModels and generateNoArgsConstructorOnly

### DIFF
--- a/src/main/resources/templates/java-lang/type.ftl
+++ b/src/main/resources/templates/java-lang/type.ftl
@@ -53,7 +53,7 @@ public class ${className} implements java.io.Serializable<#if implements?has_con
     public ${className}() {
     }
 
-<#if fields?has_content && !generateNoArgsConstructorOnly>
+<#if fields?has_content && (!generateNoArgsConstructorOnly || immutableModels)>
     public ${className}(<#list fields as field>${field.type} ${field.name}<#if field_has_next>, </#if></#list>) {
     <#list fields as field>
         this.${field.name} = ${field.name};
@@ -202,7 +202,7 @@ public class ${className} implements java.io.Serializable<#if implements?has_con
     </#if>
 
         public ${className} build() {
-<#if generateNoArgsConstructorOnly>
+<#if !immutableModels && generateNoArgsConstructorOnly>
             ${className} result = new ${className}();
     <#list fields as field>
         <#if field.visibility == 'public'>

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenImmutableTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenImmutableTest.java
@@ -39,4 +39,20 @@ class GraphQLCodegenImmutableTest {
                 new File("src/test/resources/expected-classes/immutable/Event.java.txt"),
                 getFileByName(files, "Event.java"));
     }
+
+    @Test
+    void generate_noArgs_CheckFiles() throws Exception {
+      mappingConfig.setPackageName("com.kobylynskyi.graphql.immutable");
+      mappingConfig.setGenerateImmutableModels(true);
+      mappingConfig.setGenerateNoArgsConstructorOnly(true);
+
+      new JavaGraphQLCodegen(singletonList("src/test/resources/schemas/test.graphqls"),
+        outputBuildDir, mappingConfig, TestUtils.getStaticGeneratedInfo(mappingConfig)).generate();
+
+      File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
+
+      assertSameTrimmedContent(
+        new File("src/test/resources/expected-classes/immutable/Event.java.txt"),
+        getFileByName(files, "Event.java"));
+    }
 }

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenTest.java
@@ -463,7 +463,7 @@ class GraphQLCodegenTest {
     void generate_PublicFields_NoArgsConstructor_immutableModels() throws Exception {
         mappingConfig.setGenerateModelsWithPublicFields(true);
         mappingConfig.setGenerateNoArgsConstructorOnly(true);
-        mappingConfig.setGenerateImmutableModels(true);
+        mappingConfig.setGenerateImmutableModels(false);
         mappingConfig.setGenerateClient(true);
 
         generate("src/test/resources/schemas/test.graphqls");
@@ -483,7 +483,7 @@ class GraphQLCodegenTest {
     void generate_PublicFields_NoBuilder_NoArgsConstructor() throws Exception {
         mappingConfig.setGenerateModelsWithPublicFields(true);
         mappingConfig.setGenerateNoArgsConstructorOnly(true);
-        mappingConfig.setGenerateImmutableModels(true);
+        mappingConfig.setGenerateImmutableModels(false);
         mappingConfig.setGenerateBuilder(false);
 
         generate("src/test/resources/schemas/test.graphqls");


### PR DESCRIPTION
---
### Description

Related to #1285: This PR patches the conflict between generateImmutableModels and generateNoArgsConstructor config. When generateImmutableModels = true a constructor with all fields as arguments is always created. This constructor is also used in build().

---

Changes were made to:
- [x] Codegen library - Java
- [ ] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
