### PR TITLE
Fix #1429: Support custom type default values for enum

### DIFF
--- a/src/main/java/com/kobylynskyi/graphql/codegen/mapper/ValueMapper.java
+++ b/src/main/java/com/kobylynskyi/graphql/codegen/mapper/ValueMapper.java
@@ -17,7 +17,6 @@ import graphql.language.Value;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -123,16 +122,14 @@ public class ValueMapper {
 
     private String mapEnum(MappingContext mappingContext, EnumValue value, Type<?> graphQLType) {
         if (graphQLType == null) {
-            Map<String, String> customTypesMapping = mappingContext.getCustomTypesMapping();
-            if (customTypesMapping.containsKey(value.getName())) {
-                return customTypesMapping.get(value.getName());
-            }
-
-            return value.getName();
+            String typeName = value.getName();
+            return mappingContext.getCustomTypesMapping().getOrDefault(typeName, typeName);
         }
         if (graphQLType instanceof TypeName) {
             String typeName = ((TypeName) graphQLType).getName();
-            typeName = DataModelMapper.getModelClassNameWithPrefixAndSuffix(mappingContext, typeName);
+            typeName = mappingContext.getCustomTypesMapping().getOrDefault(typeName,
+                    DataModelMapper.getModelClassNameWithPrefixAndSuffix(mappingContext, typeName)
+            );
             return typeName + "." + dataModelMapper.capitalizeIfRestricted(mappingContext, value.getName());
         }
         if (graphQLType instanceof NonNullType) {

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenCustomScalarMappingTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenCustomScalarMappingTest.java
@@ -9,13 +9,18 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Objects;
 
 import static com.kobylynskyi.graphql.codegen.TestUtils.assertSameTrimmedContent;
 import static com.kobylynskyi.graphql.codegen.TestUtils.getFileByName;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class GraphQLCodegenCustomScalarMappingTest {
 
@@ -84,6 +89,28 @@ class GraphQLCodegenCustomScalarMappingTest {
         assertSameTrimmedContent(
                 new File("src/test/resources/expected-classes/custom-type/ExternalResolver.java.txt"),
                 getFileByName(files, "ExternalResolver.java"));
+    }
+
+    /**
+     * See #1429
+     */
+    @Test
+    void generate_CustomTypeMapping_ForEnumWithDefaultValue() throws Exception {
+        mappingConfig.setGenerateExtensionFieldsResolvers(true);
+        mappingConfig.setCustomTypesMapping(singletonMap("MyEnum", "com.example.MyOtherEnum"));
+        mappingConfig.setGenerateClient(false);
+
+        generate("src/test/resources/schemas/defaults.graphqls");
+
+        File[] files = Objects.requireNonNull(outputJavaClassesDir.listFiles());
+        List<String> generatedFileNames = Arrays.stream(files).map(File::getName).sorted().collect(toList());
+        assertEquals(asList("InputWithDefaults.java", "MyEnum.java", "SomeObject.java"), generatedFileNames);
+
+        for (File file : files) {
+            assertSameTrimmedContent(
+                    new File(String.format("src/test/resources/expected-classes/default-custom-types/%s.txt",
+                            file.getName())), file);
+        }
     }
 
     private void generate(String path) throws IOException {

--- a/src/test/resources/expected-classes/default-custom-types/InputWithDefaults.java.txt
+++ b/src/test/resources/expected-classes/default-custom-types/InputWithDefaults.java.txt
@@ -1,0 +1,211 @@
+package com.kobylynskyi.graphql.test1;
+
+
+/**
+ * This input has all possible types
+ */
+@javax.annotation.Generated(
+    value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+    date = "2020-12-31T23:59:59-0500"
+)
+public class InputWithDefaults implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Double floatVal = 1.23;
+    private Boolean booleanVal = false;
+    private Integer intVal = 42;
+    private String stringVal = "my-default";
+    private com.example.MyOtherEnum enumVal = com.example.MyOtherEnum.ONE;
+    @javax.validation.constraints.NotNull
+    private com.example.MyOtherEnum nonNullEnumVal = com.example.MyOtherEnum.TWO;
+    private SomeObject objectWithNullDefault = null;
+    private SomeObject objectWithNonNullDefault;
+    private java.util.List<Integer> intList = java.util.Arrays.asList(1, 2, 3);
+    private java.util.List<Integer> intListEmptyDefault = java.util.Collections.emptyList();
+    @javax.validation.constraints.NotNull
+    private java.util.List<SomeObject> objectListEmptyDefault = java.util.Collections.emptyList();
+
+    public InputWithDefaults() {
+    }
+
+    public InputWithDefaults(Double floatVal, Boolean booleanVal, Integer intVal, String stringVal, com.example.MyOtherEnum enumVal, com.example.MyOtherEnum nonNullEnumVal, SomeObject objectWithNullDefault, SomeObject objectWithNonNullDefault, java.util.List<Integer> intList, java.util.List<Integer> intListEmptyDefault, java.util.List<SomeObject> objectListEmptyDefault) {
+        this.floatVal = floatVal;
+        this.booleanVal = booleanVal;
+        this.intVal = intVal;
+        this.stringVal = stringVal;
+        this.enumVal = enumVal;
+        this.nonNullEnumVal = nonNullEnumVal;
+        this.objectWithNullDefault = objectWithNullDefault;
+        this.objectWithNonNullDefault = objectWithNonNullDefault;
+        this.intList = intList;
+        this.intListEmptyDefault = intListEmptyDefault;
+        this.objectListEmptyDefault = objectListEmptyDefault;
+    }
+
+    public Double getFloatVal() {
+        return floatVal;
+    }
+    public void setFloatVal(Double floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    public Boolean getBooleanVal() {
+        return booleanVal;
+    }
+    public void setBooleanVal(Boolean booleanVal) {
+        this.booleanVal = booleanVal;
+    }
+
+    public Integer getIntVal() {
+        return intVal;
+    }
+    public void setIntVal(Integer intVal) {
+        this.intVal = intVal;
+    }
+
+    public String getStringVal() {
+        return stringVal;
+    }
+    public void setStringVal(String stringVal) {
+        this.stringVal = stringVal;
+    }
+
+    public com.example.MyOtherEnum getEnumVal() {
+        return enumVal;
+    }
+    public void setEnumVal(com.example.MyOtherEnum enumVal) {
+        this.enumVal = enumVal;
+    }
+
+    public com.example.MyOtherEnum getNonNullEnumVal() {
+        return nonNullEnumVal;
+    }
+    public void setNonNullEnumVal(com.example.MyOtherEnum nonNullEnumVal) {
+        this.nonNullEnumVal = nonNullEnumVal;
+    }
+
+    public SomeObject getObjectWithNullDefault() {
+        return objectWithNullDefault;
+    }
+    public void setObjectWithNullDefault(SomeObject objectWithNullDefault) {
+        this.objectWithNullDefault = objectWithNullDefault;
+    }
+
+    public SomeObject getObjectWithNonNullDefault() {
+        return objectWithNonNullDefault;
+    }
+    public void setObjectWithNonNullDefault(SomeObject objectWithNonNullDefault) {
+        this.objectWithNonNullDefault = objectWithNonNullDefault;
+    }
+
+    public java.util.List<Integer> getIntList() {
+        return intList;
+    }
+    public void setIntList(java.util.List<Integer> intList) {
+        this.intList = intList;
+    }
+
+    public java.util.List<Integer> getIntListEmptyDefault() {
+        return intListEmptyDefault;
+    }
+    public void setIntListEmptyDefault(java.util.List<Integer> intListEmptyDefault) {
+        this.intListEmptyDefault = intListEmptyDefault;
+    }
+
+    public java.util.List<SomeObject> getObjectListEmptyDefault() {
+        return objectListEmptyDefault;
+    }
+    public void setObjectListEmptyDefault(java.util.List<SomeObject> objectListEmptyDefault) {
+        this.objectListEmptyDefault = objectListEmptyDefault;
+    }
+
+
+
+    public static InputWithDefaults.Builder builder() {
+        return new InputWithDefaults.Builder();
+    }
+
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
+    public static class Builder {
+
+        private Double floatVal = 1.23;
+        private Boolean booleanVal = false;
+        private Integer intVal = 42;
+        private String stringVal = "my-default";
+        private com.example.MyOtherEnum enumVal = com.example.MyOtherEnum.ONE;
+        private com.example.MyOtherEnum nonNullEnumVal = com.example.MyOtherEnum.TWO;
+        private SomeObject objectWithNullDefault = null;
+        private SomeObject objectWithNonNullDefault;
+        private java.util.List<Integer> intList = java.util.Arrays.asList(1, 2, 3);
+        private java.util.List<Integer> intListEmptyDefault = java.util.Collections.emptyList();
+        private java.util.List<SomeObject> objectListEmptyDefault = java.util.Collections.emptyList();
+
+        public Builder() {
+        }
+
+        public Builder setFloatVal(Double floatVal) {
+            this.floatVal = floatVal;
+            return this;
+        }
+
+        public Builder setBooleanVal(Boolean booleanVal) {
+            this.booleanVal = booleanVal;
+            return this;
+        }
+
+        public Builder setIntVal(Integer intVal) {
+            this.intVal = intVal;
+            return this;
+        }
+
+        public Builder setStringVal(String stringVal) {
+            this.stringVal = stringVal;
+            return this;
+        }
+
+        public Builder setEnumVal(com.example.MyOtherEnum enumVal) {
+            this.enumVal = enumVal;
+            return this;
+        }
+
+        public Builder setNonNullEnumVal(com.example.MyOtherEnum nonNullEnumVal) {
+            this.nonNullEnumVal = nonNullEnumVal;
+            return this;
+        }
+
+        public Builder setObjectWithNullDefault(SomeObject objectWithNullDefault) {
+            this.objectWithNullDefault = objectWithNullDefault;
+            return this;
+        }
+
+        public Builder setObjectWithNonNullDefault(SomeObject objectWithNonNullDefault) {
+            this.objectWithNonNullDefault = objectWithNonNullDefault;
+            return this;
+        }
+
+        public Builder setIntList(java.util.List<Integer> intList) {
+            this.intList = intList;
+            return this;
+        }
+
+        public Builder setIntListEmptyDefault(java.util.List<Integer> intListEmptyDefault) {
+            this.intListEmptyDefault = intListEmptyDefault;
+            return this;
+        }
+
+        public Builder setObjectListEmptyDefault(java.util.List<SomeObject> objectListEmptyDefault) {
+            this.objectListEmptyDefault = objectListEmptyDefault;
+            return this;
+        }
+
+
+        public InputWithDefaults build() {
+            return new InputWithDefaults(floatVal, booleanVal, intVal, stringVal, enumVal, nonNullEnumVal, objectWithNullDefault, objectWithNonNullDefault, intList, intListEmptyDefault, objectListEmptyDefault);
+        }
+
+    }
+}

--- a/src/test/resources/expected-classes/default-custom-types/MyEnum.java.txt
+++ b/src/test/resources/expected-classes/default-custom-types/MyEnum.java.txt
@@ -1,0 +1,24 @@
+package com.kobylynskyi.graphql.test1;
+
+@javax.annotation.Generated(
+    value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+    date = "2020-12-31T23:59:59-0500"
+)
+public enum MyEnum {
+
+    ONE("ONE"),
+    TWO("TWO"),
+    THREE("THREE");
+
+    private final String graphqlName;
+
+    private MyEnum(String graphqlName) {
+        this.graphqlName = graphqlName;
+    }
+
+    @Override
+    public String toString() {
+        return this.graphqlName;
+    }
+
+}

--- a/src/test/resources/expected-classes/default-custom-types/SomeObject.java.txt
+++ b/src/test/resources/expected-classes/default-custom-types/SomeObject.java.txt
@@ -1,0 +1,57 @@
+package com.kobylynskyi.graphql.test1;
+
+
+@javax.annotation.Generated(
+    value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+    date = "2020-12-31T23:59:59-0500"
+)
+public class SomeObject implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @javax.validation.constraints.NotNull
+    private String name;
+
+    public SomeObject() {
+    }
+
+    public SomeObject(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+
+    public static SomeObject.Builder builder() {
+        return new SomeObject.Builder();
+    }
+
+    @javax.annotation.Generated(
+        value = "com.kobylynskyi.graphql.codegen.GraphQLCodegen",
+        date = "2020-12-31T23:59:59-0500"
+    )
+    public static class Builder {
+
+        private String name;
+
+        public Builder() {
+        }
+
+        public Builder setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+
+        public SomeObject build() {
+            return new SomeObject(name);
+        }
+
+    }
+}


### PR DESCRIPTION
### Description

Related to #1429
Support default value for custom types mapped Enums.

Given
`direction: OrderDirection = ASC`
and
`<OrderDirection>foo.bar.OrderDirection</OrderDirection>`

Before
`private foo.bar.OrderDirection direction = OrderDirection.ASC;`
After:
`private foo.bar.OrderDirection direction = foo.bar.OrderDirection.ASC;`

---

Couldn't sleep, so thought I'd made myself useful.

---

Changes were made to:
- [X] Codegen library