### PR TITLE
Update dependencies for gradle and maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,14 +19,14 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.freemarker:freemarker:2.3.32"
-    compileOnly "com.graphql-java:graphql-java:20.2"
-    compileOnly "com.fasterxml.jackson.core:jackson-databind:2.15.3"
+    compileOnly "org.freemarker:freemarker:2.3.34"
+    compileOnly "com.graphql-java:graphql-java:20.9"
+    compileOnly "com.fasterxml.jackson.core:jackson-databind:2.15.4"
     compileOnly "com.typesafe:config:1.4.3"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.2"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.2"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.5"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.5"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.5"
     testImplementation "org.hamcrest:java-hamcrest:2.0.0.0"
 }
 

--- a/plugins/gradle/example-client-kotlin/build.gradle
+++ b/plugins/gradle/example-client-kotlin/build.gradle
@@ -32,14 +32,14 @@ dependencies {
 
     implementation "javax.validation:validation-api:2.0.1.Final"
     implementation "com.squareup.okhttp3:okhttp:4.11.0"
-    implementation "com.fasterxml.jackson.core:jackson-core:2.15.3"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.15.3"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:2.15.3"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.15.4"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.15.4"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.15.4"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.15.4"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.2"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.5"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.5"
 }
 
 /**

--- a/plugins/gradle/example-client/build.gradle
+++ b/plugins/gradle/example-client/build.gradle
@@ -30,12 +30,12 @@ dependencies {
     implementation "org.mapstruct:mapstruct:1.5.5.Final"
     annotationProcessor "org.mapstruct:mapstruct-processor:1.5.5.Final"
 
-    compileOnly "org.projectlombok:lombok:1.18.30"
-    annotationProcessor "org.projectlombok:lombok:1.18.30"
+    compileOnly "org.projectlombok:lombok:1.18.36"
+    annotationProcessor "org.projectlombok:lombok:1.18.36"
 
     testImplementation "io.rest-assured:rest-assured:5.3.2"
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.2"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.5"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.5"
 }
 
 

--- a/plugins/gradle/example-server/build.gradle
+++ b/plugins/gradle/example-server/build.gradle
@@ -21,8 +21,8 @@ dependencies {
 
     implementation "javax.validation:validation-api:2.0.1.Final"
 
-    compileOnly "org.projectlombok:lombok:1.18.30"
-    annotationProcessor "org.projectlombok:lombok:1.18.30"
+    compileOnly "org.projectlombok:lombok:1.18.36"
+    annotationProcessor "org.projectlombok:lombok:1.18.36"
 
     implementation 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 

--- a/plugins/gradle/graphql-java-codegen-gradle-plugin/build.gradle
+++ b/plugins/gradle/graphql-java-codegen-gradle-plugin/build.gradle
@@ -26,13 +26,13 @@ dependencies {
 
     implementation "io.github.kobylynskyi:graphql-java-codegen:${version}"
 
-    implementation "org.freemarker:freemarker:2.3.32"
-    implementation "com.graphql-java:graphql-java:20.2"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.15.3"
+    implementation "org.freemarker:freemarker:2.3.34"
+    implementation "com.graphql-java:graphql-java:20.9"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.15.4"
     implementation "com.typesafe:config:1.4.3"
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.5'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.5'
 }
 
 gradlePlugin {

--- a/plugins/maven/example-client/pom.xml
+++ b/plugins/maven/example-client/pom.xml
@@ -106,7 +106,7 @@
                         <annotationProcessorPath>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.26</version>
+                            <version>1.18.36</version>
                         </annotationProcessorPath>
                         <annotationProcessorPath>
                             <groupId>org.mapstruct</groupId>
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>2.7.10</version>
+            <version>2.7.18</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.30</version>
+            <version>1.18.36</version>
         </dependency>
 
         <dependency>
@@ -185,12 +185,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.10.2</version>
+            <version>5.10.5</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.10.2</version>
+            <version>5.10.5</version>
         </dependency>
     </dependencies>
 

--- a/plugins/maven/example-server/pom.xml
+++ b/plugins/maven/example-server/pom.xml
@@ -59,7 +59,7 @@
                         <annotationProcessorPath>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.26</version>
+                            <version>1.18.36</version>
                         </annotationProcessorPath>
                         <annotationProcessorPath>
                             <groupId>org.mapstruct</groupId>
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.30</version>
+            <version>1.18.36</version>
         </dependency>
     </dependencies>
 

--- a/plugins/maven/graphql-java-codegen-maven-plugin/pom.xml
+++ b/plugins/maven/graphql-java-codegen-maven-plugin/pom.xml
@@ -116,17 +116,17 @@
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.32</version>
+            <version>2.3.34</version>
         </dependency>
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>20.2</version>
+            <version>20.9</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.3</version>
+            <version>2.15.4</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe</groupId>


### PR DESCRIPTION
---

### Description

Updated dependencies for maven and gradle versions.
These are a bump of certain dependencies to fix vulnerabilities in graphql dependency.
Builds worked locally for gradle/maven with 1.8 java target.
I did not touch dependencies of Scala/SBT, I have no experience with that tool/language.

---

Changes were made to:
- [X] Codegen library - Java
- [X] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [X] Maven plugin
- [X] Gradle plugin
- [ ] SBT plugin
