### PR TITLE
Fxi sbt GithubActions

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -14,7 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+        
+      - uses: sbt/setup-sbt@v1
+      - uses: coursier/cache-action@v6
+      
       # brew install sbt; cd graphql-java-codegen-sbt-plugin; sbt fmt or sbt check
       - name: Check Scala Code Style
         working-directory: plugins/sbt/graphql-java-codegen-sbt-plugin

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -16,7 +16,7 @@ jobs:
         jdk-version: [ 8, 11, 17 ]
     steps:
       - uses: actions/checkout@v4
-
+      
       - name: Setup Java ${{ matrix.jdk-version }}
         uses: actions/setup-java@v4
         with:
@@ -73,7 +73,10 @@ jobs:
       - name: Build sbt plugin
         working-directory: plugins/sbt/graphql-java-codegen-sbt-plugin
         run: sbt compile publishLocal --debug
-
+        
+      - uses: sbt/setup-sbt@v1
+      - uses: coursier/cache-action@v6
+      
       - name: Build sbt test
         working-directory: plugins/sbt/graphql-java-codegen-sbt-plugin
         run: sbt scripted

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -34,7 +34,10 @@ jobs:
         with:
           path: ~/.m2
           key: m2
-
+        
+      - uses: sbt/setup-sbt@v1
+      - uses: coursier/cache-action@v6
+      
       - name: Loading ivy cache
         uses: actions/cache@v4
         with:
@@ -73,9 +76,6 @@ jobs:
       - name: Build sbt plugin
         working-directory: plugins/sbt/graphql-java-codegen-sbt-plugin
         run: sbt compile publishLocal --debug
-        
-      - uses: sbt/setup-sbt@v1
-      - uses: coursier/cache-action@v6
       
       - name: Build sbt test
         working-directory: plugins/sbt/graphql-java-codegen-sbt-plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,10 @@ jobs:
         with:
           path: ~/.m2
           key: m2
-
+          
+      - uses: sbt/setup-sbt@v1
+      - uses: coursier/cache-action@v6
+      
       - name: Loading ivy cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
---
It is recommended to migrate the release of the sbt plugin to the same groupid. Of course, I'm happy to continue maintaining it, but it's better to unify it like this, and I can also use codegen's secret directly.

### Description

Related to #ISSUE_NUMBER

---

Changes were made to:
- [ ] Codegen library - Java
- [ ] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
